### PR TITLE
ported sequence from shapeless.contrib.scalaz here.

### DIFF
--- a/core/src/main/scala/cats/sequence/package.scala
+++ b/core/src/main/scala/cats/sequence/package.scala
@@ -1,0 +1,2 @@
+package cats
+package object sequence extends SequenceOps

--- a/core/src/main/scala/cats/sequence/sequence.scala
+++ b/core/src/main/scala/cats/sequence/sequence.scala
@@ -1,0 +1,79 @@
+/*
+ * Adapted from shapeless-contrib scalaz
+ * https://github.com/typelevel/shapeless-contrib/blob/v0.4/scalaz/main/scala/sequence.scala
+ *
+ */
+package cats.sequence
+
+import shapeless._
+
+import cats._
+
+import scala.annotation.implicitNotFound
+
+trait Apply2[FH, OutT] {
+  type Out
+  def apply(fh: FH, outT: OutT): Out
+}
+
+object Apply2 {
+  type Aux[FH, OutT, Out0] = Apply2[FH, OutT] { type Out = Out0 }
+
+  implicit def apply2[F[_], H, T <: HList](implicit app: Apply[F]): Aux[F[H], F[T], F[H :: T]] =
+    new Apply2[F[H], F[T]] {
+      type Out = F[H :: T]
+      def apply(fh: F[H], outT: F[T]): Out = app.ap(outT)(app.map(fh)(( (_:H) :: (_:T)).curried))
+    }
+
+  implicit def apply2a[F[_, _], A, H, T <: HList](implicit app: Apply[F[A, ?]]): Aux[F[A, H], F[A, T], F[A, H :: T]] =
+    apply2[F[A, ?], H, T]
+}
+
+@implicitNotFound("cannot construct sequencer, make sure that every item of you hlist ${L} is an Applicative")
+trait Sequencer[L <: HList] {
+  type Out
+  def apply(in: L): Out
+}
+
+trait LowPrioritySequencer {
+  type Aux[L <: HList, Out0] = Sequencer[L] { type Out = Out0 }
+
+  implicit def consSequencerAux[FH, FT <: HList, OutT]
+  (implicit
+   st: Aux[FT, OutT],
+   ap: Apply2[FH, OutT]
+  ): Aux[FH :: FT, ap.Out] =
+    new Sequencer[FH :: FT] {
+      type Out = ap.Out
+      def apply(in: FH :: FT): Out = ap(in.head, st(in.tail))
+    }
+}
+
+object Sequencer extends LowPrioritySequencer {
+  implicit def nilSequencerAux[F[_]: Applicative]: Aux[HNil, F[HNil]] =
+    new Sequencer[HNil] {
+      type Out = F[HNil]
+      def apply(in: HNil): F[HNil] = Applicative[F].pure(HNil: HNil)
+    }
+
+  implicit def singleSequencerAux[FH]
+  (implicit
+   un: Unapply[Functor, FH]
+  ): Aux[FH :: HNil, un.M[un.A :: HNil]] =
+    new Sequencer[FH :: HNil] {
+      type Out = un.M[un.A :: HNil]
+      def apply(in: FH :: HNil): Out = un.TC.map(un.subst(in.head)) { _ :: HNil }
+    }
+}
+
+trait SequenceOps {
+  implicit class sequenceFunction[L <: HList](self: L) {
+    def sequence(implicit seq: Sequencer[L]): seq.Out = seq(self)
+  }
+
+  object sequence extends ProductArgs {
+    def applyProduct[L <: HList](l: L)(implicit seq: Sequencer[L]): seq.Out = seq(l)
+  }
+}
+
+object SequenceOps extends SequenceOps

--- a/core/src/test/scala/cats/sequence/sequence.scala
+++ b/core/src/test/scala/cats/sequence/sequence.scala
@@ -1,0 +1,79 @@
+/*
+  Adapted from shapeless-contrib scalaz
+ */
+package cats.sequence
+
+import cats._
+import cats.data._, Xor._
+import cats.implicits._
+import org.scalacheck.Arbitrary, Arbitrary.arbitrary
+import shapeless._
+import cats.derived._
+import org.scalacheck.Prop.forAll
+import scala.language.existentials
+class SequenceTests extends KittensSuite {
+  import SequenceTests._
+
+  test("sequencing Option")(check {
+    forAll { (x: Option[Int], y: Option[String], z: Option[Float]) =>
+      val expected = (x |@| y |@| z) map (_ :: _ :: _ :: HNil)
+      (x :: y :: z :: HNil).sequence == expected
+    }
+  })
+
+  test("sequencing Xor")(check {
+    forAll { (x: Xor[String, Int], y: Xor[String, String], z: Xor[String, Float]) =>
+      val expected = (x |@| y |@| z) map (_ :: _ :: _ :: HNil)
+      (x :: y :: z :: HNil).sequence == expected
+    }
+  })
+
+  // note: using the ValidationNel type alias here breaks the implicit search
+  test("sequencing ValidatedNel")(check {
+    forAll { (x: Validated[NonEmptyList[String], Int], y: Validated[NonEmptyList[String], String], z: Validated[NonEmptyList[String], Float]) =>
+      val expected = (x |@| y |@| z) map (_ :: _ :: _ :: HNil)
+      sequence(x, y, z) == expected
+    }
+  })
+
+  test("sequencing Function"){
+    val f1 = (_: String).length
+    val f2 = (_: String).reverse
+    val f3 = (_: String).toDouble
+
+    val f = (f1 :: f2 :: f3 :: HNil).sequence
+    assert( f("42.0") == 4 :: "0.24" :: 42.0 :: HNil)
+  }
+
+  test("sequencing Function using ProductArgs"){
+    val f1 = (_: String).length
+    val f2 = (_: String).reverse
+    val f3 = (_: String).toDouble
+
+    val f = sequence(f1, f2, f3)
+    assert( f("42.0") == 4 :: "0.24" :: 42.0 :: HNil )
+
+  }
+
+}
+
+object SequenceTests {
+  implicit def nelSemiGroup[A]: Semigroup[NonEmptyList[A]] = implicitly[SemigroupK[NonEmptyList]].algebra[A]
+
+  implicit def xora[A: Arbitrary, B: Arbitrary]: Arbitrary[Xor[A, B]] = Arbitrary(
+    for {
+      a <- arbitrary[A]
+      left <- arbitrary[Boolean]
+      b <- arbitrary[B]
+    } yield if(left) Left(a) else Right(b)
+  )
+
+  implicit def validatedNel[A: Arbitrary, B: Arbitrary]: Arbitrary[ValidatedNel[A, B]] = Arbitrary(
+    for {
+      a <- arbitrary[A]
+      as <- arbitrary[List[A]]
+      left <- arbitrary[Boolean]
+      b <- arbitrary[B]
+    } yield if(left) Validated.Invalid(NonEmptyList(a, as:_*)) else Validated.valid(b)
+  )
+}


### PR DESCRIPTION
May this be the first step of porting scalaz-shapeless utils here.