### PR TITLE
Added sequence for record and generic case classes 

### DIFF
--- a/core/src/main/scala/cats/sequence/sequence.scala
+++ b/core/src/main/scala/cats/sequence/sequence.scala
@@ -8,6 +8,8 @@ package cats.sequence
 import shapeless._
 
 import cats._
+import shapeless.ops.hlist.ZipWithKeys
+import shapeless.ops.record.{Values, Keys}
 
 import scala.annotation.implicitNotFound
 
@@ -66,13 +68,72 @@ object Sequencer extends LowPrioritySequencer {
     }
 }
 
+
+trait ValueSequencer[L <: HList] {
+  type Out
+  def apply(in: L): Out
+}
+
+
+object ValueSequencer {
+  type Aux[L <: HList, Out0] = ValueSequencer[L] { type Out = Out0 }
+
+  implicit def recordValueAux[L <: HList, V <: HList]
+  (implicit
+   values:    Values.Aux[L, V],
+   sequencer: Sequencer[V]): Aux[L, sequencer.Out] = new ValueSequencer[L] {
+    type Out = sequencer.Out
+    def apply(in: L): Out = sequencer(values(in))
+  }
+
+}
+
+
+@implicitNotFound("cannot construct sequencer, make sure that every field value of you record ${L} is an Applicative")
+trait RecordSequencer[L <: HList] {
+  type Out
+  def apply(in: L): Out
+}
+
+
+object RecordSequencer {
+  type Aux[L <: HList, Out0] = RecordSequencer[L] { type Out = Out0 }
+
+  implicit def recordSequencerAux[L <: HList, VFOut, F[_], K <: HList, VOut <: HList]
+  (implicit
+   valueSequencer: ValueSequencer.Aux[L, VFOut],
+   un:        Unapply.Aux1[Functor, VFOut, F, VOut],
+   keys:      Keys.Aux[L, K],
+   zip:       ZipWithKeys[K, VOut]
+  ): Aux[L, F[zip.Out]] = new RecordSequencer[L] {
+    type Out = F[zip.Out]
+    def apply(in: L): Out = {
+      un.TC.map(un.subst(valueSequencer(in)))(zip(_))
+    }
+  }
+
+  implicit def recordSequencerAuxRight[L <: HList, VFOut, A,  F[_, _], K <: HList, VOut <: HList]
+  (implicit
+   valueSequencer: ValueSequencer.Aux[L, VFOut],
+   un: Unapply.Aux2Right[Functor, VFOut, F, A, VOut],
+   keys:      Keys.Aux[L, K],
+   zip:       ZipWithKeys[K, VOut]
+  ): Aux[L, F[A, zip.Out]] = recordSequencerAux[L, VFOut, F[A, ?], K, VOut]
+}
+
+
 trait SequenceOps {
   implicit class sequenceFunction[L <: HList](self: L) {
     def sequence(implicit seq: Sequencer[L]): seq.Out = seq(self)
+    def sequenceRecord(implicit seq: RecordSequencer[L]): seq.Out = seq(self)
   }
 
   object sequence extends ProductArgs {
     def applyProduct[L <: HList](l: L)(implicit seq: Sequencer[L]): seq.Out = seq(l)
+  }
+
+  object sequenceRecord extends RecordArgs {
+    def applyRecord[L <: HList](l: L)(implicit seq: RecordSequencer[L]): seq.Out = seq(l)
   }
 }
 

--- a/core/src/test/scala/cats/sequence/sequence.scala
+++ b/core/src/test/scala/cats/sequence/sequence.scala
@@ -7,10 +7,11 @@ import cats._
 import cats.data._, Xor._
 import cats.implicits._
 import org.scalacheck.Arbitrary, Arbitrary.arbitrary
-import shapeless._
+import shapeless._, shapeless.syntax.singleton._
 import cats.derived._
 import org.scalacheck.Prop.forAll
 import scala.language.existentials
+
 class SequenceTests extends KittensSuite {
   import SequenceTests._
 
@@ -53,6 +54,38 @@ class SequenceTests extends KittensSuite {
     val f = sequence(f1, f2, f3)
     assert( f("42.0") == 4 :: "0.24" :: 42.0 :: HNil )
 
+  }
+
+  test("sequencing record of Option")(check {
+    forAll { (x: Option[Int], y: Option[String], z: Option[Float]) =>
+      val expected = for ( a <- x; b <- y; c <- z ) yield ('a ->> a) :: ('b ->> b) :: ( 'c ->> c) :: HNil
+      (('a ->> x) :: ('b ->> y) :: ('c ->> z) :: HNil).sequenceRecord == expected
+    }
+  })
+
+  test("sequencing record of Option using RecordArgs")(check {
+    forAll { (x: Option[Int], y: Option[String], z: Option[Float]) =>
+
+      val expected = for ( a <- x; b <- y; c <- z ) yield ('a ->> a) :: ('b ->> b) :: ( 'c ->> c) :: HNil
+      sequenceRecord(a = x, b = y, c = z) == expected
+    }
+  })
+
+  test("sequencing record of Xor")(check {
+    forAll { (x: Xor[String, Int], y: Xor[String, String], z: Xor[String, Float]) =>
+
+      val expected = for ( a <- x; b <- y; c <- z ) yield ('a ->> a) :: ('b ->> b) :: ( 'c ->> c) :: HNil
+      (('a ->> x) :: ('b ->> y) :: ('c ->> z) :: HNil).sequenceRecord == expected
+    }
+  })
+
+  test("sequencing record of Functions through RecordArgs") {
+    val f1 = (_: String).length
+    val f2 = (_: String).reverse
+    val f3 = (_: String).toDouble
+
+    val f = sequenceRecord(a = f1, b = f2, c = f3)
+    assert( f("42.0") == ('a ->> 4) :: ('b ->> "0.24") :: ('c ->> 42.0) :: HNil )
   }
 
 }

--- a/core/src/test/scala/cats/sequence/sequence.scala
+++ b/core/src/test/scala/cats/sequence/sequence.scala
@@ -88,6 +88,26 @@ class SequenceTests extends KittensSuite {
     assert( f("42.0") == ('a ->> 4) :: ('b ->> "0.24") :: ('c ->> 42.0) :: HNil )
   }
 
+  case class MyCase(a: Int, b: String, c: Float)
+
+  test("sequence gen for Option")(check {
+    forAll { (x: Option[Int], y: Option[String], z: Option[Float]) =>
+      val myGen = sequenceGeneric[MyCase]
+      val expected = (x |@| y |@| z) map MyCase.apply
+
+      myGen(a = x, b = y, c = z) == expected
+    }
+  })
+
+  test("sequence gen for Xor")(check {
+    forAll { (x: Xor[String, Int], y: Xor[String, String], z: Xor[String, Float]) =>
+      val myGen = sequenceGeneric[MyCase]
+      val expected = (x |@| y |@| z) map MyCase.apply
+
+      myGen(a = x, b = y, c = z) == expected
+    }
+  })
+
 }
 
 object SequenceTests {


### PR DESCRIPTION
example usage
```
  import cats.sequence._
  import cats.implicits._

  case class MyCase(a: Int, b: String, c: Float)

  val myGen = sequenceGeneric[MyCase]

  myGen(a = Option(1), b = Option("23"), c = Option(2.2))  //gives Some(MyCase(1, "23", 2.2))
  
```

Please help review the code. I had to duplicate between Functor[F[_]] and Functor[F[A, ?]], any advice on how to reduce such duplication? 