### PR TITLE
refactor to eliminate a different sequence ops name for record

### DIFF
--- a/core/src/test/scala/cats/sequence/sequence.scala
+++ b/core/src/test/scala/cats/sequence/sequence.scala
@@ -58,7 +58,7 @@ class SequenceTests extends KittensSuite {
   test("sequencing record of Option")(check {
     forAll { (x: Option[Int], y: Option[String], z: Option[Float]) =>
       val expected = for ( a <- x; b <- y; c <- z ) yield ('a ->> a) :: ('b ->> b) :: ( 'c ->> c) :: HNil
-      (('a ->> x) :: ('b ->> y) :: ('c ->> z) :: HNil).sequenceRecord == expected
+      (('a ->> x) :: ('b ->> y) :: ('c ->> z) :: HNil).sequence == expected
     }
   })
 
@@ -74,7 +74,7 @@ class SequenceTests extends KittensSuite {
     forAll { (x: Xor[String, Int], y: Xor[String, String], z: Xor[String, Float]) =>
 
       val expected = for ( a <- x; b <- y; c <- z ) yield ('a ->> a) :: ('b ->> b) :: ( 'c ->> c) :: HNil
-      (('a ->> x) :: ('b ->> y) :: ('c ->> z) :: HNil).sequenceRecord == expected
+      (('a ->> x) :: ('b ->> y) :: ('c ->> z) :: HNil).sequence == expected
     }
   })
 


### PR DESCRIPTION
based on @milessabin 's SO answer to this [question](http://stackoverflow.com/questions/34846947/how-to-create-overloads-for-product-and-record)
