### PR TITLE
For review only (do not merge yet) - added an applicative based on pure foldable and functor

### DIFF
--- a/core/src/main/scala/cats/derived/applicative.scala
+++ b/core/src/main/scala/cats/derived/applicative.scala
@@ -1,0 +1,41 @@
+package cats.derived
+
+import cats.{Foldable, Functor, Eval, Applicative}, Eval.now
+import alleycats.Pure
+import export.{ exports, imports, reexports }
+import shapeless._
+
+
+@reexports[MkApplicative]
+object applicative {
+  @imports[Applicative]
+  object legacy
+}
+
+trait MkApplicative[F[_]] extends Applicative[F]
+
+@exports
+object MkApplicative {
+  def apply[F[_]](implicit maf: MkApplicative[F]): MkApplicative[F] = maf
+
+  implicit def fromFunctorPureAndFoldable[F[_]](
+     implicit
+     F: Functor[F],
+     P: Pure[F],
+     Fdb: Foldable[F]
+  ): MkApplicative[F] = new MkApplicative[F] {
+    def pure[A](x: A): F[A] = P.pure(x)
+
+    def ap[A, B](ff: F[A => B])(fa: F[A]): F[B] = {
+      val ph : F[B] = null.asInstanceOf[F[B]]
+      Fdb.foldLeft[A => B, F[B]](ff, ph)((_, f) => F.map(fa)(f))
+    }
+
+    def map[A, B](fa: F[A])(f: A => B): F[B] = F.map(fa)(f)
+
+    def product[A, B](fa: F[A], fb: F[B]): F[(A, B)] = {
+      val ph: F[(A, B)] = null.asInstanceOf[F[(A,B)]]
+      Fdb.foldLeft[A, F[(A, B)]](fa, ph)((_, a) => F.map(fb)((a, _)))
+    }
+  }
+}

--- a/core/src/test/scala/cats/derived/applicative.scala
+++ b/core/src/test/scala/cats/derived/applicative.scala
@@ -1,0 +1,97 @@
+/*
+ * Copyright (c) 2015 Miles Sabin
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package cats.derived
+import cats.{ Eq, Eval, Foldable, Functor, Applicative}, Eval.now
+
+import alleycats.Pure, alleycats.std.all._
+
+import cats.std.int._
+
+import TestDefns._
+
+import emptyk._, pure._, functor._, functor.legacy._, foldable._, foldable.legacy._
+
+//import applicative._
+
+
+
+class ApplicativeTests extends KittensSuite {
+
+
+  test("Applicative[IList]") {
+
+    val A = MkApplicative[IList]
+
+    // some basic sanity checks
+    val lns = (1 to 10).toList
+    val ns = IList.fromSeq(lns)
+    val fPlusOne = A.pure((_: Int) + 1)
+
+    assert(A.ap(fPlusOne)(ns) === IList.fromSeq((2 to 11).toList))
+
+
+    // more basic checks
+    val lnames = List("Aaron", "Betty", "Calvin", "Deirdre")
+    val names = IList.fromSeq(lnames)
+    val fLength = A.pure((_:String).length)
+    val lengths = A.ap(fLength)(names)
+
+    assert(lengths === IList.fromSeq(lnames.map(_.length)))
+
+    // test trampolining todo: not working yet
+    //    val llarge = 1 to 10000
+    //    val large = IList.fromSeq(llarge)
+    //
+    //    assert(A.ap(fPlusOne)(large) === IList.fromSeq(llarge.map(_+1)))
+  }
+
+  test("Applicative[Tree]") {
+    val A = MkApplicative[Tree]
+
+    val tree: Tree[String] =
+      Node(
+        Leaf("quux"),
+        Node(
+          Leaf("foo"),
+          Leaf("wibble")
+        )
+      )
+
+    val expected: Tree[Int] =
+      Node(
+        Leaf(4),
+        Node(
+          Leaf(3),
+          Leaf(6)
+        )
+      )
+    val fLength = A.pure((_:String).length)
+
+    assert(A.ap(fLength)(tree) == expected)
+  }
+
+  test("Applicative[λ[t => List[List[t]]]") {
+    type LList[T] = List[List[T]]
+    val A = MkApplicative[LList]
+
+    val l = List(List(1), List(2, 3), List(4, 5, 6), List(), List(7))
+    val expected = List(List(2), List(3, 4), List(5, 6, 7), List(), List(8))
+    val fPlusOne = A.pure((_: Int) + 1)
+
+    assert(A.ap(fPlusOne)(l) == expected)
+  }
+}


### PR DESCRIPTION
trampolining doesn't seem to work, @milessabin can you take a look?
another thing I am not sure is how to do reexport, since this Applicative requires derived Functor while itself also implements Functor, import both derived.applicative._ and dervied.functor._ causing ambiguous implicits problem, thus I don't know how to achieve auto derivation of `Applicative`. 