### PR TITLE
Added the ability to derive Monad and Apply

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,9 +17,9 @@ script:
           "${TRAVIS_BRANCH}" == "master" &&
           $(cat version.sbt) =~ "-SNAPSHOT"
     ]]; then
-      sbt ++${TRAVIS_SCALA_VERSION} validate publish ;
+      travis_wait 50 sbt ++${TRAVIS_SCALA_VERSION} validate publish ;
     else
-      sbt ++${TRAVIS_SCALA_VERSION} validate ;
+      travis_wait 50 sbt ++${TRAVIS_SCALA_VERSION} validate ;
     fi
 
 sudo: false

--- a/build.sbt
+++ b/build.sbt
@@ -53,8 +53,8 @@ lazy val commonJvmSettings = Seq(
 lazy val coreSettings = buildSettings ++ commonSettings ++ publishSettings ++ releaseSettings
 
 lazy val root = project.in(file("."))
-  .aggregate(coreJS, coreJVM)
-  .dependsOn(coreJS, coreJVM)
+  .aggregate(coreJS, coreJVM, extraTests)
+  .dependsOn(coreJS, coreJVM, extraTests)
   .settings(coreSettings:_*)
   .settings(noPublishSettings)
 
@@ -63,6 +63,13 @@ lazy val core = crossProject.crossType(CrossType.Pure)
   .settings(coreSettings:_*)
   .jsSettings(commonJsSettings:_*)
   .jvmSettings(commonJvmSettings:_*)
+
+//Monad and Applicative tests are taking a long time to compile, separating them to another module to help development, and scala 2.10.x build on travis.
+lazy val extraTests = project.in(file("extra-tests"))
+  .settings(moduleName := "kittens-tests")
+  .dependsOn(coreJVM % "compile->compile;test->test")
+  .settings(coreSettings:_*)
+  .settings(noPublishSettings)
 
 lazy val coreJVM = core.jvm
 lazy val coreJS = core.js

--- a/core/src/main/scala/cats/derived/apply.scala
+++ b/core/src/main/scala/cats/derived/apply.scala
@@ -1,0 +1,58 @@
+package cats.derived
+
+import cats.{Foldable, Functor, Eval, Apply}, Eval.now
+import alleycats.{EmptyK, Pure}
+import export.{ exports, imports, reexports }
+import shapeless._
+
+// todo doesn't work because an implicit Functor needs to be scope while Apply itself implements Functor
+//@reexports[MkApply]
+//object apply {
+//  @imports[Apply]
+//  object legacy
+//}
+
+trait MkApply[F[_]] extends Apply[F]
+
+@exports
+object MkApply extends MkApply0 {
+  def apply[F[_]](implicit maf: MkApply[F]): MkApply[F] = maf
+}
+
+trait MkApply0 extends MkApply1 {
+  implicit def mkWithEmptyK[F[_]](
+     implicit
+     F: Cached[Functor[F]],
+     E: Cached[EmptyK[F]],
+     Fdb: Cached[Foldable[F]]
+  ): MkApply[F] = doMkWithEmptyK(E.value, F.value)
+}
+
+trait MkApply1 {
+  implicit def mkWithoutEmpty[F[_]](
+     implicit
+     F: Cached[Functor[F]],
+     Fdb: Cached[Foldable[F]]
+  ): MkApply[F] = {
+    val nullEmpty = new EmptyK[F] {
+      def empty[A]: F[A] = null.asInstanceOf[F[A]]
+    }
+    doMkWithEmptyK(nullEmpty, F.value)
+  }
+
+  protected def doMkWithEmptyK[F[_]](E: EmptyK[F], F: Functor[F])(
+    implicit
+    Fdb: Cached[Foldable[F]]
+  ): MkApply[F] = new MkApply[F] {
+    def ap[A, B](ff: F[A => B])(fa: F[A]): F[B] = {
+      Fdb.value.foldLeft[A => B, F[B]](ff, E.empty[B])((_, f) => F.map(fa)(f))
+    }
+
+    def map[A, B](fa: F[A])(f: A => B): F[B] = F.map(fa)(f)
+
+    def product[A, B](fa: F[A], fb: F[B]): F[(A, B)] = {
+      Fdb.value.foldLeft[A, F[(A, B)]](fa, E.empty[(A, B)])((_, a) => F.map(fb)((a, _)))
+    }
+  }
+
+}

--- a/core/src/main/scala/cats/derived/monad.scala
+++ b/core/src/main/scala/cats/derived/monad.scala
@@ -1,0 +1,55 @@
+package cats.derived
+
+import cats._, Eval.now
+import alleycats.{ConsK, EmptyK, Pure}
+import export.{ exports, imports, reexports }
+import shapeless._
+
+
+@reexports[MkMonad]
+object monad {
+  @imports[Monad]
+  object legacy
+}
+
+trait MkMonad[F[_]] extends Monad[F]
+
+@exports
+object MkMonad extends MkMonad0 {
+  def apply[F[_]](implicit mmf: MkMonad[F]): MkMonad[F] = mmf
+}
+
+trait MkMonad0 extends MkMonad1 {
+  implicit def withConsK[F[_]](
+    implicit
+    P: Cached[Pure[F]],
+    C: Cached[ConsK[F]],
+    E: Cached[EmptyK[F]],
+    F: Cached[Foldable[F]]
+  ): MkMonad[F] = new MkMonad[F] {
+    def pure[A](x: A): F[A] = P.value.pure(x)
+
+    def flatMap[A, B](fa: F[A])(f: (A) => F[B]): F[B] = {
+      F.value.foldRight[A, F[B]](fa, now(E.value.empty[B])) { (a, l) =>
+        val fb = f(a)
+        F.value.foldRight(fb, l)((b, memo) => now(C.value.cons(b, memo.value)))
+      }.value
+    }
+  }
+}
+
+
+trait MkMonad1 {
+  implicit def withoutConsK[F[_]](
+    implicit
+    P: Cached[Pure[F]],
+    E: Cached[EmptyK[F]],
+    F: Cached[Foldable[F]]
+  ): MkMonad[F] = new MkMonad[F] {
+    def pure[A](x: A): F[A] = P.value.pure(x)
+
+    def flatMap[A, B](fa: F[A])(f: (A) => F[B]): F[B] = {
+      F.value.foldLeft[A, F[B]](fa, E.value.empty[B])((_, a) => f(a))
+    }
+  }
+}

--- a/core/src/test/scala/cats/derived/adtdefns.scala
+++ b/core/src/test/scala/cats/derived/adtdefns.scala
@@ -43,4 +43,7 @@ object TestDefns {
   sealed trait Tree[T]
   final case class Leaf[T](t: T) extends Tree[T]
   final case class Node[T](l: Tree[T], r: Tree[T]) extends Tree[T]
+
+  case class CaseClassWOption[T](a: Option[T])
+
 }

--- a/core/src/test/scala/cats/derived/foldable.scala
+++ b/core/src/test/scala/cats/derived/foldable.scala
@@ -19,7 +19,6 @@ package cats.derived
 import cats.{ Eq, Eval, Foldable }, Eval.now
 
 import TestDefns._
-
 class FoldableTests extends KittensSuite {
   // disable scalatest ===
   override def convertToEqualizer[T](left: T): Equalizer[T] = ???

--- a/core/src/test/scala/cats/derived/functor.scala
+++ b/core/src/test/scala/cats/derived/functor.scala
@@ -22,6 +22,7 @@ import TestDefns._
 
 import functor._, legacy._
 import iterable.legacy._
+import shapeless.cachedImplicit
 
 class FunctorTests extends KittensSuite {
 

--- a/core/src/test/scala/cats/derived/pure.scala
+++ b/core/src/test/scala/cats/derived/pure.scala
@@ -50,7 +50,7 @@ class PureTests extends KittensSuite {
   }
 
   test("Pure[IList]") {
-    val P = Pure[IList]
+    val P = cachedImplicit[Pure[IList]]
 
     assert(P.pure(23) == ICons(23, INil()))
   }

--- a/extra-tests/src/test/scala/cats/derived/apply.scala
+++ b/extra-tests/src/test/scala/cats/derived/apply.scala
@@ -1,0 +1,158 @@
+/*
+ * Copyright (c) 2016 Miles Sabin
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package cats.derived
+import cats.{ Eq, Eval, Foldable, Functor, Apply}, Eval.now
+
+import alleycats.Pure, alleycats.std.all._
+
+import cats.std.int._
+
+import TestDefns._
+import shapeless.Cached
+
+//import apply._ todo: export hook conflicts with functor
+
+class ApplyTests extends KittensSuite {
+  import emptyk._, pure._
+
+  import ApplyTests._
+
+  test("Apply[CaseClassWOption]") {
+    import Implicits.{ccO, fccO}
+
+    val M = MkApply[CaseClassWOption]
+    val p1 = CaseClassWOption(Option(1))
+    val f =  CaseClassWOption(Option((_: Int) + 1))
+
+    assert(M.ap(f)(p1) == CaseClassWOption(Option(2)))
+    assert(M.ap(f)(CaseClassWOption(None)) == CaseClassWOption(None))
+    val emptyF = CaseClassWOption[Int => Int](None)
+    assert(M.ap(emptyF)(CaseClassWOption(Option(1))) == CaseClassWOption(None))
+
+  }
+
+  test("Apply[IList]") {
+    import Implicits.{l, fl}
+
+    val A = MkApply[IList]
+
+    // some basic sanity checks
+    val lns = (1 to 10).toList
+    val ns = IList.fromSeq(lns)
+    val fPlusOne = IList.fromSeq(List((_: Int) + 1))
+
+    assert(A.ap(fPlusOne)(ns) === IList.fromSeq((2 to 11).toList))
+
+
+    // more basic checks
+    val lnames = List("Aaron", "Betty", "Calvin", "Deirdre")
+    val names = IList.fromSeq(lnames)
+    val fLength = IList.fromSeq(List((_: String).length))
+    val lengths = A.ap(fLength)(names)
+
+    assert(lengths === IList.fromSeq(lnames.map(_.length)))
+
+    // test trampolining
+    val llarge = 1 to 10000
+    val large = IList.fromSeq(llarge)
+    val resultList = MkIterable[IList].iterable(A.ap(fPlusOne)(large)).toList
+
+    assert(resultList === llarge.map(_ + 1))
+  }
+
+  test("Apply[λ[t => List[List[t]]]") {
+    import Implicits.{ll, fll}
+
+    val A = MkApply[LList]
+
+    val l = List(List(1), List(2, 3), List(4, 5, 6), List(), List(7))
+    val expected = List(List(2), List(3, 4), List(5, 6, 7), List(), List(8))
+    val fPlusOne: LList[Int => Int] = List(List((_: Int) + 1))
+
+    assert(A.ap(fPlusOne)(l) == expected)
+  }
+}
+
+class ApplyWithoutEmptyKTests extends KittensSuite {
+
+  import ApplyTests.Implicits.{t, ft}
+
+  test("Apply[Tree]") {
+    val A = MkApply[Tree]
+
+    val tree: Tree[String] =
+      Node(
+        Leaf("quux"),
+        Node(
+          Leaf("foo"),
+          Leaf("wibble")
+        )
+      )
+
+    val expected: Tree[Int] =
+      Node(
+        Leaf(4),
+        Node(
+          Leaf(3),
+          Leaf(6)
+        )
+      )
+    val fLength: Tree[String => Int] = Leaf((_: String).length)
+
+    assert(A.ap(fLength)(tree) == expected)
+  }
+
+}
+
+
+object ApplyTests {
+  import emptyk._, pure._
+  type LList[T] = List[List[T]]
+  import shapeless.cachedImplicit
+
+  //Has to isolate Foldable and Functor derivation,
+  // on scala 2.10.x they can't co exist in the same scope
+  // todo: remove this manual step once Foldable and Functor can co exist on 2.10.x
+  object FoldableDeriveProxy {
+    import foldable._ , foldable.legacy._
+
+    lazy val ccO = cachedImplicit[Foldable[CaseClassWOption]]
+    lazy val iList = cachedImplicit[Foldable[IList]]
+    lazy val t = cachedImplicit[Foldable[Tree]]
+    lazy val lList = cachedImplicit[Foldable[LList]]
+  }
+
+  object FunctorDeriveProxy {
+    import functor._ , functor.legacy._
+    lazy val ccO = cachedImplicit[Functor[CaseClassWOption]]
+    lazy val iList = cachedImplicit[Functor[IList]]
+    lazy val t = cachedImplicit[Functor[Tree]]
+    lazy val lList = cachedImplicit[Functor[LList]]
+  }
+
+  object Implicits {
+    implicit lazy val ccO: Foldable[CaseClassWOption] = FoldableDeriveProxy.ccO
+    implicit lazy val l:  Foldable[IList] = FoldableDeriveProxy.iList
+    implicit lazy val t: Foldable[Tree] = FoldableDeriveProxy.t
+    implicit lazy val ll: Foldable[LList] = FoldableDeriveProxy.lList
+    implicit lazy val fccO: Functor[CaseClassWOption] = FunctorDeriveProxy.ccO
+    implicit lazy val fl: Functor[IList] = FunctorDeriveProxy.iList
+    implicit lazy val ft: Functor[Tree] = FunctorDeriveProxy.t
+    implicit lazy val fll: Functor[LList] = FunctorDeriveProxy.lList
+  }
+
+}

--- a/extra-tests/src/test/scala/cats/derived/monad.scala
+++ b/extra-tests/src/test/scala/cats/derived/monad.scala
@@ -1,0 +1,78 @@
+/*
+ * Copyright (c) 2015 Miles Sabin
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package cats.derived
+
+import cats.data.Xor
+import cats.laws.MonadLaws
+import cats.{Eval, Foldable}, Eval.now
+
+import alleycats.{EmptyK, ConsK, Pure}, alleycats.std.all._
+
+import cats.std.int._
+
+import TestDefns._
+
+
+//import monad._ todo: importing causes compiler to hang
+import shapeless.the
+
+
+
+class MonadTests extends KittensSuite {
+
+  test("Monad[CaseClassWOption]") {
+    import emptyk._, pure._, foldable._, foldable.legacy._
+
+    val M = MkMonad[CaseClassWOption]
+    val p1 = M.pure(1)
+    val f = (i : Int) => M.pure(i + 1)
+    assert(M.flatMap(p1)(f) == CaseClassWOption(Option(2)))
+
+    assert(M.flatMap(CaseClassWOption(None))(f) == CaseClassWOption(None))
+
+  }
+
+  test("Monad[IList]") {
+    import emptyk._, pure._, consk.exports._, foldable._, foldable.legacy._
+
+    val A = MkMonad[IList]
+
+    // some basic sanity checks
+    val lns = (1 to 10).toList
+    val ns = IList.fromSeq(lns)
+    val fPlusOne = (i: Int) => A.pure(i + 1)
+
+    assert(A.flatMap(ns)(fPlusOne) === IList.fromSeq((2 to 11).toList))
+
+
+    // more basic checks
+    val lnames = List("Aaron", "Betty", "Calvin", "Deirdre")
+    val names = IList.fromSeq(lnames)
+    val fLength = (s:String) => A.pure(s.length)
+    val lengths = A.flatMap(names)(fLength)
+
+    assert(lengths === IList.fromSeq(lnames.map(_.length)))
+
+    //trampoline
+    val llarge = 1 to 10000
+    val large = IList.fromSeq(llarge)
+    val result = A.flatMap(large)(fPlusOne)
+    val resultList = MkIterable[IList].iterable(result).toList
+    assert(resultList === llarge.map(_+1))
+  }
+
+}


### PR DESCRIPTION
Notes to @milessabin Trampoline works properly (It was an error in the test.)
Exporting doesn't work yet. Partly due the fact that since this Apply requires derived Functor while itself also implements Functor, import both derived.apply._ and dervied.functor._ causing ambiguous implicits problem, thus I don't know how to achieve auto derivation. 
For monad, compiler hangs when `importing both monad and foldable`.. 