### PR TITLE
SI2712 fix + applicative

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: scala
 
 scala:
-- 2.11.7
+- 2.11.8
 - 2.10.6
 
 jdk:

--- a/build.sbt
+++ b/build.sbt
@@ -29,6 +29,7 @@ lazy val commonSettings = Seq(
     "org.scalacheck"  %% "scalacheck"     % "1.12.5" % "test",
     "org.typelevel"   %% "discipline"     % "0.4" % "test",
 
+    compilerPlugin("com.milessabin" % "si2712fix-plugin" % "1.1.0" cross CrossVersion.full),
     compilerPlugin("org.spire-math" %% "kind-projector" % "0.6.3")
   ),
 

--- a/core/src/main/scala/cats/derived/applicative.scala
+++ b/core/src/main/scala/cats/derived/applicative.scala
@@ -1,0 +1,18 @@
+package cats.derived
+
+import alleycats.Pure
+import cats.{Apply, Applicative, Foldable, Functor}
+
+object MkApplicative {
+
+  implicit def mkApplicative[F[_]](
+    implicit
+    P: MkPure[F], //on scala 2.10.6 `Pure`'s `applicativeIsPure` is somehow conflicting with auto derived Applicative and Pure
+    A: Apply[F]
+ ): Applicative[F] = new Applicative[F] {
+    def pure[A](x: A): F[A] = P.pure(x)
+
+    def ap[A, B](ff: F[(A) => B])(fa: F[A]): F[B] = A.ap(ff)(fa)
+  }
+
+}

--- a/core/src/main/scala/cats/sequence/sequence.scala
+++ b/core/src/main/scala/cats/sequence/sequence.scala
@@ -19,22 +19,35 @@ trait HListApply2[FH, OutT] extends Serializable {
   def apply(fh: FH, outT: OutT): Out
 }
 
-object HListApply2 {
+object HListApply2 extends MkHListApply2 {
   type Aux[FH, OutT, Out0] = HListApply2[FH, OutT] { type Out = Out0 }
 
+
+}
+
+trait MkHListApply2 extends MkHListApply2_0 {
+
+
   implicit def mkHListApply2[F[_], H, T <: HList]
-    (implicit app: Apply[F]): Aux[F[H], F[T], F[H :: T]] =
-      new HListApply2[F[H], F[T]] {
-        type Out = F[H :: T]
+  (implicit app: Apply[F]): HListApply2.Aux[F[H], F[T], F[H :: T]] =
+    new HListApply2[F[H], F[T]] {
+      type Out = F[H :: T]
 
-        def apply(fh: F[H], outT: F[T]): Out = app.map2(fh, outT)(_ :: _)
-      }
+      def apply(fh: F[H], outT: F[T]): Out = app.map2(fh, outT)(_ :: _)
+    }
 
+}
+trait MkHListApply2_0 extends MkHListApply2_1 {
+  self: MkHListApply2 =>
   implicit def mkHListApply2a[F[_, _], A, H, T <: HList]
-    (implicit app: Apply[F[A, ?]]): Aux[F[A, H], F[A, T], F[A, H :: T]] = mkHListApply2[F[A, ?], H, T]
+  (implicit app: Apply[F[A, ?]]): HListApply2.Aux[F[A, H], F[A, T], F[A, H :: T]] = mkHListApply2[F[A, ?], H, T]
 
+}
+trait MkHListApply2_1 {
+  self: MkHListApply2 =>
   implicit def mkHListApply3right[G[_], F[_[_], _, _], A, H, T <: HList]
-    (implicit app: Apply[F[G, A, ?]]): Aux[F[G, A, H], F[G, A, T], F[G, A, H :: T]] = mkHListApply2[F[G, A, ?], H, T]
+  (implicit app: Apply[F[G, A, ?]]): HListApply2.Aux[F[G, A, H], F[G, A, T], F[G, A, H :: T]] = mkHListApply2[F[G, A, ?], H, T]
+
 }
 
 @implicitNotFound("cannot construct sequencer, make sure that every item of you hlist ${L} is an Applicative")
@@ -105,81 +118,101 @@ trait RecordSequencer[L <: HList] extends Serializable {
 }
 
 
-object RecordSequencer {
+object RecordSequencer extends MkRecordSequencer {
   type Aux[L <: HList, Out0] = RecordSequencer[L] { type Out = Out0 }
-
-  implicit def mkRecordSequencer[L <: HList, VFOut, F[_], K <: HList, VOut <: HList]
-    ( implicit
-      vs: ValueSequencer.Aux[L, VFOut],
-      un: Unapply.Aux1[Functor, VFOut, F, VOut],
-      keys: Keys.Aux[L, K],
-      zip: ZipWithKeys[K, VOut]
-    ): Aux[L, F[zip.Out]] =
-      new RecordSequencer[L] {
-        type Out = F[zip.Out]
-
-        def apply(in: L): Out = {
-          un.TC.map(un.subst(vs(in)))(zip(_))
-        }
-  }
-
-  implicit def mkRecordSequencer2Right[L <: HList, VFOut, A, F[_, _], K <: HList, VOut <: HList]
-    ( implicit
-      vs: ValueSequencer.Aux[L, VFOut],
-      un: Unapply.Aux2Right[Functor, VFOut, F, A, VOut],
-      keys: Keys.Aux[L, K],
-      zip: ZipWithKeys[K, VOut]
-    ): Aux[L, F[A, zip.Out]] =
-      mkRecordSequencer[L, VFOut, F[A, ?], K, VOut]
-
-  implicit def mkRecordSequencer3Right[L <: HList, VFOut, A, G[_], F[_[_], _, _], K <: HList, VOut <: HList]
-    ( implicit
-      vs: ValueSequencer.Aux[L, VFOut],
-      un: Unapply.Aux3MTRight[Functor, VFOut, F, G, A, VOut],
-      keys: Keys.Aux[L, K],
-      zip: ZipWithKeys[K, VOut]
-    ): Aux[L, F[G, A, zip.Out]] =
-      mkRecordSequencer[L, VFOut, F[G, A, ?], K, VOut]
 }
 
-trait GenericSequencer[L <: HList, T] extends Serializable {
+trait MkRecordSequencer extends MkRecordSequencer0 {
+  implicit def mkRecordSequencer[L <: HList, VFOut, F[_], K <: HList, VOut <: HList]
+  ( implicit
+    vs: ValueSequencer.Aux[L, VFOut],
+    un: Unapply.Aux1[Functor, VFOut, F, VOut],
+    keys: Keys.Aux[L, K],
+    zip: ZipWithKeys[K, VOut]
+  ): RecordSequencer.Aux[L, F[zip.Out]] =
+    new RecordSequencer[L] {
+      type Out = F[zip.Out]
+
+      def apply(in: L): Out = {
+        un.TC.map(un.subst(vs(in)))(zip(_))
+      }
+    }
+}
+
+trait MkRecordSequencer0 extends MkRecordSequencer1 {
+  self: MkRecordSequencer =>
+  implicit def mkRecordSequencer2Right[L <: HList, VFOut, A, F[_, _], K <: HList, VOut <: HList]
+  ( implicit
+    vs: ValueSequencer.Aux[L, VFOut],
+    un: Unapply.Aux2Right[Functor, VFOut, F, A, VOut],
+    keys: Keys.Aux[L, K],
+    zip: ZipWithKeys[K, VOut]
+  ): RecordSequencer.Aux[L, F[A, zip.Out]] =
+    mkRecordSequencer[L, VFOut, F[A, ?], K, VOut]
+}
+
+trait MkRecordSequencer1 {
+  self: MkRecordSequencer =>
+  implicit def mkRecordSequencer3Right[L <: HList, VFOut, A, G[_], F[_[_], _, _], K <: HList, VOut <: HList]
+  ( implicit
+    vs: ValueSequencer.Aux[L, VFOut],
+    un: Unapply.Aux3MTRight[Functor, VFOut, F, G, A, VOut],
+    keys: Keys.Aux[L, K],
+    zip: ZipWithKeys[K, VOut]
+  ): RecordSequencer.Aux[L, F[G, A, zip.Out]] =
+    mkRecordSequencer[L, VFOut, F[G, A, ?], K, VOut]
+}
+
+  trait GenericSequencer[L <: HList, T] extends Serializable {
   type Out
 
   def apply(l: L): Out
 }
 
-object GenericSequencer {
+object GenericSequencer extends MkGenericSequencer {
   type Aux[L <: HList, T, Out0] = GenericSequencer[L, T] { type Out = Out0 }
+}
+
+trait MkGenericSequencer extends MkGenericSequencer0 {
 
   implicit def mkGenericSequencer[L <: HList, T, SOut <: HList, FOut, F[_]]
-    ( implicit
-      rs: RecordSequencer.Aux[L, FOut],
-      gen: LabelledGeneric.Aux[T, SOut],
-      un: Unapply.Aux1[Functor, FOut, F, SOut]
-    ): Aux[L, T, F[T]] =
-      new GenericSequencer[L, T] {
-        type Out = F[T]
+  ( implicit
+    rs: RecordSequencer.Aux[L, FOut],
+    gen: LabelledGeneric.Aux[T, SOut],
+    un: Unapply.Aux1[Functor, FOut, F, SOut]
+  ): GenericSequencer.Aux[L, T, F[T]] =
+    new GenericSequencer[L, T] {
+      type Out = F[T]
 
-        def apply(in: L): Out = {
-          un.TC.map(un.subst(rs(in)))(gen.from)
+      def apply(in: L): Out = {
+        un.TC.map(un.subst(rs(in)))(gen.from)
       }
-  }
+    }
 
+}
+
+trait MkGenericSequencer0 extends MkGenericSequencer1 {
+  self: MkGenericSequencer =>
   implicit def mkGenericSequencer2Right[L <: HList, T, SOut <: HList, FOut, A, F[_, _]]
-    ( implicit
-      rs: RecordSequencer.Aux[L, FOut],
-      gen: LabelledGeneric.Aux[T, SOut],
-      un: Unapply.Aux2Right[Functor, FOut, F, A, SOut]
-    ): Aux[L, T, F[A, T]] =
-      mkGenericSequencer[L, T, SOut, FOut, F[A, ?]]
+  ( implicit
+    rs: RecordSequencer.Aux[L, FOut],
+    gen: LabelledGeneric.Aux[T, SOut],
+    un: Unapply.Aux2Right[Functor, FOut, F, A, SOut]
+  ): GenericSequencer.Aux[L, T, F[A, T]] =
+    mkGenericSequencer[L, T, SOut, FOut, F[A, ?]]
+
+}
+
+trait MkGenericSequencer1 {
+  self: MkGenericSequencer =>
 
   implicit def mkGenericSequencer3Right[L <: HList, T, SOut <: HList, FOut, A, G[_], F[_[_], _, _]]
-    ( implicit
-      rs: RecordSequencer.Aux[L, FOut],
-      gen: LabelledGeneric.Aux[T, SOut],
-      un: Unapply.Aux3MTRight[Functor, FOut, F, G, A, SOut]
-    ): Aux[L, T, F[G, A, T]] =
-      mkGenericSequencer[L, T, SOut, FOut, F[G, A, ?]]
+  ( implicit
+    rs: RecordSequencer.Aux[L, FOut],
+    gen: LabelledGeneric.Aux[T, SOut],
+    un: Unapply.Aux3MTRight[Functor, FOut, F, G, A, SOut]
+  ): GenericSequencer.Aux[L, T, F[G, A, T]] =
+    mkGenericSequencer[L, T, SOut, FOut, F[G, A, ?]]
 }
 
 

--- a/extra-tests/src/test/scala/cats/derived/applicative.scala
+++ b/extra-tests/src/test/scala/cats/derived/applicative.scala
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) 2016 Miles Sabin
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package cats.derived
+import cats.Applicative
+import alleycats.Pure, alleycats.std.all._
+import cats.std.int._
+
+import TestDefns._
+
+class ApplicativeTests extends KittensSuite {
+  import emptyk._, pure._
+  import MkApplicative._
+  import MkApply._
+  import ApplyTests._
+
+
+  test("Applicative[IList]") {
+    import Implicits.{l, fl}
+
+    val A = Applicative[IList]
+
+    // some basic sanity checks
+    val lns = (1 to 10).toList
+    val ns = IList.fromSeq(lns)
+    val fPlusOne = IList.fromSeq(List((_: Int) + 1))
+
+    assert(A.ap(fPlusOne)(ns) === IList.fromSeq((2 to 11).toList))
+
+  }
+
+}
+


### PR DESCRIPTION
update: 
Additional notes. This is a simple fix that
1,  moves si-2712 work arounds for `sequence` implicits to priority implicit traits, and
2, provides an `Applicative` derivation simply from `Pure` and `Apply` since both can be also derived.  