### PR TITLE
Introduce generalization for "Copair" types like Either, Xor, Validated, A :+: B :+: CNil

### DIFF
--- a/core/src/main/scala/cats/generalized/copair.scala
+++ b/core/src/main/scala/cats/generalized/copair.scala
@@ -23,7 +23,7 @@ trait Copair[F[_,_]] extends Bitraverse[F] {
 
   def exists[A, B](f: F[A,B])(fn: B => Boolean): Boolean = fold(f)(_ => false, fn)
 
-  def to[G[_, _], A, B](f: F[A, B])(implicit G: Copair[G]): G[A,B] = fold(f)(G.left, G.right)
+  def toCopair[G[_, _], A, B](f: F[A, B])(implicit G: Copair[G]): G[A,B] = fold(f)(G.left, G.right)
 
   def bitraverse[G[_], A, B, C, D](fab: F[A, B])(f: A => G[C], g: B => G[D])(implicit G: Applicative[G]): G[F[C, D]] =
     fold(fab)(
@@ -118,7 +118,7 @@ final class CopairOps[F[_,_], A, B](pair: F[A,B])(implicit F: Copair[F]) {
 
   def exists(fn: B => Boolean): Boolean = F.exists(pair)(fn)
 
-  def to[G[_, _]](implicit G: Copair[G]): G[A,B] = F.to[G,A,B](pair)
+  def toCopair[G[_, _]](implicit G: Copair[G]): G[A,B] = F.toCopair[G,A,B](pair)
 
 }
 

--- a/core/src/main/scala/cats/generalized/copair.scala
+++ b/core/src/main/scala/cats/generalized/copair.scala
@@ -1,0 +1,128 @@
+package cats.generalized
+
+import cats.{Applicative, Bitraverse, Eval}
+import cats.data.{Validated, Xor}
+import shapeless._
+
+trait Copair[F[_,_]] extends Bitraverse[F] {
+  def left[A,B](a: A): F[A,B]
+  def right[A,B](b: B): F[A,B]
+
+  def fold[A,B,C](f: F[A,B])(fa: A => C, fb: B => C): C
+
+  def isRight[A,B](f: F[A,B]): Boolean = fold(f)(_ => false, _ => true )
+  def isLeft[A,B](f: F[A,B]):  Boolean = fold(f)(_ => true , _ => false)
+
+  def foreach[A,B](f: F[A,B])(fn: B => Unit): Unit = fold(f)(_ => (), fn)
+
+  def swap[A,B](f: F[A,B]): F[B,A] = fold(f)(right[B, A], left[B, A])
+
+  def swapped[A,B,C,D](f: F[A,B])(fn: F[B,A] => F[C,D]): F[D,C] = swap(fn(swap(f)))
+
+  def forall[A, B](f: F[A,B])(fn: B => Boolean): Boolean = fold(f)(_ => true, fn)
+
+  def exists[A, B](f: F[A,B])(fn: B => Boolean): Boolean = fold(f)(_ => false, fn)
+
+  def to[G[_, _], A, B](f: F[A, B])(implicit G: Copair[G]): G[A,B] = fold(f)(G.left, G.right)
+
+  def bitraverse[G[_], A, B, C, D](fab: F[A, B])(f: A => G[C], g: B => G[D])(implicit G: Applicative[G]): G[F[C, D]] =
+    fold(fab)(
+      l => G.map(f(l))(left),
+      r => G.map(g(r))(right)
+    )
+
+  def bifoldLeft[A, B, C](fab: F[A, B], c: C)(f: (C, A) => C, g: (C, B) => C): C =
+    fold(fab)(
+      l => f(c,l),
+      r => g(c,r)
+    )
+
+  def bifoldRight[A, B, C](fab: F[A, B], c: Eval[C])(f: (A, Eval[C]) => Eval[C], g: (B, Eval[C]) => Eval[C]): Eval[C] =
+    fold(fab)(
+      l => f(l,c),
+      r => g(r,c)
+    )
+}
+
+trait CopairSyntax {
+  implicit def copairSyntax[F[_, _]: Copair, A, B](fab: F[A, B]): CopairOps[F, A, B] =
+    new CopairOps[F, A, B](fab)
+
+  implicit def copairIdSyntax[A](a: A): CopairIdOps[A] = new CopairIdOps[A](a)
+}
+
+trait CopairInstances {
+
+  implicit def validatedCopair: Copair[Validated] =
+    new Copair[Validated] {
+      def fold[A, B, C](f: Validated[A, B])(fa: (A) => C, fb: (B) => C): C =
+        f match {
+          case Validated.Invalid(a) => fa(a)
+          case Validated.Valid(b) => fb(b)
+        }
+
+      def left[A, B](a: A): Validated[A, B] = Validated.Invalid(a)
+      def right[A, B](b: B): Validated[A, B] = Validated.Valid(b)
+    }
+
+  implicit def xorCopair: Copair[Xor] =
+    new Copair[Xor] {
+      def fold[A, B, C](f: Xor[A, B])(fa: (A) => C, fb: (B) => C): C =
+        f match {
+          case Xor.Left(a) => fa(a)
+          case Xor.Right(b) => fb(b)
+        }
+
+      def left[A, B](a: A): Xor[A, B] = Xor.Left(a)
+      def right[A, B](b: B): Xor[A, B] = Xor.Right(b)
+    }
+
+  implicit val eitherCopair: Copair[Either] =
+    new Copair[Either] {
+      def fold[A, B, C](f: Either[A, B])(fa: (A) => C, fb: (B) => C): C =
+        f match {
+          case Left(a) => fa(a)
+          case Right(b) => fb(b)
+        }
+
+      def left[A, B](a: A): Either[A, B] = Left(a)
+      def right[A, B](b: B): Either[A, B] = Right(b)
+    }
+
+  type ShapelessCoproduct2[A, B] = A :+: B :+: CNil
+  implicit val shapelessCoproductCopair: Copair[ShapelessCoproduct2] =
+    new Copair[ShapelessCoproduct2] {
+      def fold[A, B, C](f: CopairInstances.this.ShapelessCoproduct2[A,B])(fa: A => C,fb: B => C): C =
+        f match {
+          case Inl(a) => fa(a)
+          case Inr(Inl(b)) => fb(b)
+          case Inr(Inr(_)) => sys.error("impossible")
+        }
+
+      def left[A, B](a: A): CopairInstances.this.ShapelessCoproduct2[A,B] = Coproduct[ShapelessCoproduct2[A,B]](a)
+      def right[A, B](b: B): CopairInstances.this.ShapelessCoproduct2[A,B] = Coproduct[ShapelessCoproduct2[A,B]](b)
+    }
+}
+
+final class CopairOps[F[_,_], A, B](pair: F[A,B])(implicit F: Copair[F]) {
+
+  def fold[C](fa: A => C, fb: B => C): C = F.fold(pair)(fa, fb)
+  def swap: F[B,A] = F.swap(pair)
+
+  def isRight: Boolean = F.isRight(pair)
+  def isLeft:  Boolean = F.isLeft(pair)
+
+  def foreach(fn: B => Unit): Unit = F.foreach(pair)(fn)
+
+  def forall(fn: B => Boolean): Boolean = F.forall(pair)(fn)
+
+  def exists(fn: B => Boolean): Boolean = F.exists(pair)(fn)
+
+  def to[G[_, _]](implicit G: Copair[G]): G[A,B] = F.to[G,A,B](pair)
+
+}
+
+final class CopairIdOps[A](a: A) {
+  def leftC[F[_,_], B](implicit F: Copair[F]): F[A,B] = F.left(a)
+  def rightC[F[_,_], B](implicit F: Copair[F]): F[B,A] = F.right(a)
+}

--- a/core/src/main/scala/cats/generalized/package.scala
+++ b/core/src/main/scala/cats/generalized/package.scala
@@ -1,0 +1,5 @@
+package cats.generalized
+
+package object generalized
+  extends CopairInstances with CopairSyntax
+

--- a/core/src/test/scala/cats/generalized/copair.scala
+++ b/core/src/test/scala/cats/generalized/copair.scala
@@ -1,0 +1,151 @@
+package cats.generalized
+
+import cats._
+import cats.data._
+import cats.laws._
+import cats.implicits._
+import cats.laws.discipline.arbitrary._
+import cats.laws.discipline._
+import org.scalacheck.Prop.forAll
+import org.scalacheck.Arbitrary
+import org.scalatest.Matchers._
+import org.scalatest.prop.Checkers._
+import org.scalatest.prop.GeneratorDrivenPropertyChecks
+import cats.derived._
+
+class CopairTest
+  extends KittensSuite
+  with GeneratorDrivenPropertyChecks
+  with CopairSyntax
+  with CopairInstances {
+
+  CopairTests[Xor].copair[Option, Int, Int, Int, String, String, String].all.check
+  CopairTests[Either].copair[Option, Int, Int, Int, String, String, String].all.check
+  CopairTests[Validated].copair[Option, Int, Int, Int, String, String, String].all.check
+
+  testCopairs[Xor]("Xor")
+  testCopairs[Either]("Either")
+  testCopairs[Validated]("Validated")
+
+  def testCopairs[F[_,_]: Copair](ofType: String)(implicit arb: Arbitrary[F[String, Int]]): Unit = {
+    test(s"$ofType Copair for-each performs side-effect") {
+
+      forAll { copair: F[String, Int] =>
+        var sideEffectOccurred = false
+        copair.foreach(_ => sideEffectOccurred = true)
+
+        sideEffectOccurred should === (copair.isRight)
+      }
+    }
+
+    test(s"$ofType Copair for-all") {
+      forAll { copair: F[String, Int] =>
+        copair.forall(_ % 2 == 0) should === (copair.fold(_ => true, _ % 2 == 0))
+      }
+    }
+
+    test(s"$ofType Copair exists") {
+      forAll { copair: F[String, Int] =>
+        copair.exists(_ % 2 == 0) should === (copair.fold(_ => false, _ % 2 == 0))
+      }
+    }
+
+    test(s"$ofType Copair left/right") {
+      forAll { copair: F[String, Int] =>
+        copair.isLeft should === (copair.fold(_ => true, _ => false))
+        copair.isRight should === (copair.fold(_ => false, _ => true))
+      }
+    }
+
+    test(s"$ofType Copair to") {
+      forAll { copair: F[String, Int] =>
+        copair.to[Xor].isLeft should === (copair.isLeft)
+        copair.to[Xor].isRight should === (copair.isRight)
+
+        val (strFold, intFold): (String => String, Int => String) = (_ => "string", _ => "int")
+        copair.to[Xor].fold(strFold, intFold) should === (copair.fold(strFold, intFold))
+      }
+    }
+
+  }
+}
+
+
+trait CopairTests[F[_,_]] extends BitraverseTests[F] with BifoldableTests[F] with BifunctorTests[F] {
+  def laws: CopairLaws[F]
+
+  def copair[G[_], A, B, C, D, E, H](implicit
+    G: Applicative[G],
+    C: Monoid[C],
+    ArbFAB: Arbitrary[F[A, B]],
+    ArbFAD: Arbitrary[F[A, D]],
+    ArbGC: Arbitrary[G[C]],
+    ArbGD: Arbitrary[G[D]],
+    ArbGE: Arbitrary[G[E]],
+    ArbGH: Arbitrary[G[H]],
+    ArbA: Arbitrary[A],
+    ArbB: Arbitrary[B],
+    ArbC: Arbitrary[C],
+    ArbE: Arbitrary[E],
+    ArbH: Arbitrary[H],
+    EqFAB: Eq[F[A, B]],
+    EqFAD: Eq[F[A, D]],
+    EqFAH: Eq[F[A, H]],
+    EqFCD: Eq[F[C, D]],
+    EqFCH: Eq[F[C, H]],
+    EqGGFEH: Eq[G[G[F[E, H]]]],
+    EqC: Eq[C]
+  ): RuleSet =
+    new RuleSet {
+      val name = "copair"
+      val parents = Seq(bitraverse[G,A,B,C,D,E,H], bifoldable[A, B, C], bifunctor[A, B, C, D, E, H])
+      val bases = Seq.empty
+      val props = Seq(
+        "copair fold identity" -> forAll(laws.copairFoldIdentity[A, B] _),
+        "copair double swap identity" -> forAll(laws.copairDoubleSwapIdentity[A,B] _),
+        "copair left swap identity" -> forAll(laws.copairLeftSwapIdentity[A, B] _),
+        "copair right swap identity" -> forAll(laws.copairRightSwapIdentity[A, B] _),
+        "copair left identity" -> forAll(laws.copairLeftIdentity[A,B,C] _),
+        "copair right identity" -> forAll(laws.copairRightIdentity[A,B,C] _),
+        "copair to identity" -> forAll(laws.copairToIdentity[A,B] _)
+      )
+    }
+}
+
+object CopairTests {
+  def apply[F[_, _]: Copair]: CopairTests[F] =
+    new CopairTests[F] { def laws: CopairLaws[F] = CopairLaws[F] }
+}
+
+trait CopairLaws[F[_,_]] extends BitraverseLaws[F] with BifoldableLaws[F] with BifunctorLaws[F] with CopairSyntax {
+  implicit override def F: Copair[F]
+
+  def copairFoldIdentity[A, B](fab: F[A, B]): IsEq[F[A, B]] =
+    fab <-> fab.fold(_.leftC[F, B], _.rightC[F, A])
+
+  def copairDoubleSwapIdentity[A,B](fab: F[A,B]): IsEq[F[A,B]] =
+    fab <-> fab.swap.swap
+
+  def copairLeftIdentity[A, B, C](a: A, fa: A => C, fb: B => C): IsEq[C] =
+    a.leftC[F, B].fold(fa, fb) <-> fa(a)
+
+  def copairRightIdentity[A, B, C](b: B, fa: A => C, fb: B => C): IsEq[C] =
+    b.rightC[F, A].fold(fa, fb) <-> fb(b)
+
+  def copairToIdentity[A, B](fab: F[A,B]): IsEq[F[A,B]] =
+    fab.to[F] <-> fab
+
+  def copairLeftSwapIdentity[A, B](b: B): IsEq[F[A, B]] =
+    b.leftC[F, A].swap <-> b.rightC[F, A]
+
+  def copairRightSwapIdentity[A, B](a: A): IsEq[F[A, B]] =
+    a.rightC[F, B].swap <-> a.leftC[F, B]
+
+}
+
+object CopairLaws {
+  def apply[F[_, _]](implicit ev: Copair[F]): CopairLaws[F] =
+    new CopairLaws[F] { def F: Copair[F] = ev }
+}
+
+


### PR DESCRIPTION
There has been some discussion on this already over in the cats repo https://github.com/typelevel/cats/pull/976.  

Some people suggested that I submit this over here instead. 
