### PR TITLE
Added SemigroupK and MonoidK derivation

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -1,3 +1,4 @@
 Cody Allen <ceedubs@gmail.com> @fourierstrick
 Kailuo Wang <kailuo.wang@gmail.com> @kailuowang
 Miles Sabin <miles@milessabin.com> @milessabin
+Georgi Krastev <joro.kr.21@gmail.com> @Joro_Kr

--- a/README.md
+++ b/README.md
@@ -142,4 +142,5 @@ kittens is built with SBT 0.13.9 or later, and its master branch is built with S
 + Cody Allen <ceedubs@gmail.com> [@fourierstrick](https://twitter.com/fourierstrick)
 + Kailuo Wang <kailuo.wang@gmail.com> [@kailuowang](https://twitter.com/kailuowang)
 + Miles Sabin <miles@milessabin.com> [@milessabin](https://twitter.com/milessabin)
++ Georgi Krastev <joro.kr.21@gmail.com> [@Joro_Kr](https://twitter.com/joro_kr)
 + Your name here :-)

--- a/core/src/main/scala/cats/derived/monoidk.scala
+++ b/core/src/main/scala/cats/derived/monoidk.scala
@@ -1,0 +1,89 @@
+/*
+ * Copyright (c) 2015 Miles Sabin
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package cats.derived
+
+import cats.{ Applicative, Monoid, MonoidK }
+import export.{ exports, imports, reexports }
+import shapeless._
+
+@reexports[MkMonoidK]
+object monoidk {
+  @imports[MonoidK]
+  object legacy
+}
+
+trait MkMonoidK[F[_]] extends MonoidK[F]
+
+@exports
+object MkMonoidK extends MkMonoidK0 {
+  def apply[F[_]](implicit mk: MkMonoidK[F]): MkMonoidK[F] = mk
+
+  implicit val hnil: MkMonoidK[Const[HNil]#λ] =
+    new MkMonoidK[Const[HNil]#λ] {
+      def empty[A] = HNil
+      def combineK[A](x: HNil, y: HNil) = HNil
+    }
+
+  implicit def hcons[F[_]](implicit ihc: IsHCons1[F, MonoidK, MkMonoidK])
+    : MkMonoidK[F] = new MkMonoidK[F] {
+      import ihc._
+      def empty[A] = pack(fh.empty, ft.empty)
+      def combineK[A](x: F[A], y: F[A]) = {
+        val (hx, tx) = unpack(x)
+        val (hy, ty) = unpack(y)
+        pack(fh.combineK(hx, hy), ft.combineK(tx, ty))
+      }
+    }
+}
+
+trait MkMonoidK0 extends MkMonoidK1 {
+  implicit def composed[F[_]](implicit split: Split1[F, MonoidK, Trivial1])
+    : MkMonoidK[F] = new MkMonoidK[F] {
+      import split._
+      def empty[A] = pack(fo.empty[I[A]])
+      def combineK[A](x: F[A], y: F[A]) =
+        pack(fo.combineK(unpack(x), unpack(y)))
+    }
+}
+
+trait MkMonoidK1 extends MkMonoidK2 {
+  implicit def applicative[F[_]](implicit split: Split1[F, Applicative, MonoidK])
+    : MkMonoidK[F] = new MkMonoidK[F] {
+      import split._
+      def empty[A] = pack(fo.pure(fi.empty[A]))
+      def combineK[A](x: F[A], y: F[A]) =
+        pack(fo.map2(unpack(x), unpack(y))(fi.combineK(_, _)))
+    }
+}
+
+trait MkMonoidK2 extends MkMonoidK3 {
+  implicit def generic[F[_]](implicit gen: Generic1[F, MkMonoidK])
+    : MkMonoidK[F] = new MkMonoidK[F] {
+      import gen._
+      def empty[A] = from(fr.empty)
+      def combineK[A](x: F[A], y: F[A]) =
+        from(fr.combineK(to(x), to(y)))
+    }
+}
+
+trait MkMonoidK3 {
+  implicit def const[T](implicit m: Monoid[T])
+    : MkMonoidK[Const[T]#λ] = new MkMonoidK[Const[T]#λ] {
+      def empty[A] = m.empty
+      def combineK[A](x: T, y: T) = m.combine(x, y)
+    }
+}

--- a/core/src/main/scala/cats/derived/semigroupk.scala
+++ b/core/src/main/scala/cats/derived/semigroupk.scala
@@ -1,0 +1,84 @@
+/*
+ * Copyright (c) 2015 Miles Sabin
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package cats.derived
+
+import cats.{ Apply, Semigroup, SemigroupK }
+import export.{ exports, imports, reexports }
+import shapeless._
+
+@reexports[MkSemigroupK]
+object semigroupk {
+  @imports[SemigroupK]
+  object legacy
+}
+
+trait MkSemigroupK[F[_]] extends SemigroupK[F]
+
+@exports
+object MkSemigroupK extends MkSemigroupK0 {
+  def apply[F[_]](implicit sgk: MkSemigroupK[F]): MkSemigroupK[F] = sgk
+
+  implicit val hnil: MkSemigroupK[Const[HNil]#λ] =
+    new MkSemigroupK[Const[HNil]#λ] {
+      def empty[A] = HNil
+      def combineK[A](x: HNil, y: HNil) = HNil
+    }
+
+  implicit def hcons[F[_]](implicit ihc: IsHCons1[F, SemigroupK, MkSemigroupK])
+    : MkSemigroupK[F] = new MkSemigroupK[F] {
+      import ihc._
+      def combineK[A](x: F[A], y: F[A]) = {
+        val (hx, tx) = unpack(x)
+        val (hy, ty) = unpack(y)
+        pack(fh.combineK(hx, hy), ft.combineK(tx, ty))
+      }
+    }
+}
+
+trait MkSemigroupK0 extends MkSemigroupK1 {
+  implicit def composed[F[_]](implicit split: Split1[F, SemigroupK, Trivial1])
+    : MkSemigroupK[F] = new MkSemigroupK[F] {
+      import split._
+      def combineK[A](x: F[A], y: F[A]) =
+        pack(fo.combineK(unpack(x), unpack(y)))
+    }
+}
+
+trait MkSemigroupK1 extends MkSemigroupK2 {
+  implicit def applied[F[_]](implicit split: Split1[F, Apply, SemigroupK])
+    : MkSemigroupK[F] = new MkSemigroupK[F] {
+      import split._
+      def combineK[A](x: F[A], y: F[A]) =
+        pack(fo.map2(unpack(x), unpack(y))(fi.combineK(_, _)))
+    }
+}
+
+trait MkSemigroupK2 extends MkSemigroupK3 {
+  implicit def generic[F[_]](implicit gen: Generic1[F, MkSemigroupK])
+    : MkSemigroupK[F] = new MkSemigroupK[F] {
+      import gen._
+      def combineK[A](x: F[A], y: F[A]) =
+        from(fr.combineK(to(x), to(y)))
+    }
+}
+
+trait MkSemigroupK3 {
+  implicit def const[T](implicit sg: Semigroup[T])
+    : MkSemigroupK[Const[T]#λ] = new MkSemigroupK[Const[T]#λ] {
+      def combineK[A](x: T, y: T) = sg.combine(x, y)
+    }
+}

--- a/core/src/test/scala/cats/derived/monoidk.scala
+++ b/core/src/test/scala/cats/derived/monoidk.scala
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) 2016 Miles Sabin
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package cats.derived
+
+import cats._, instances.all._, kernel.laws.GroupLaws
+
+import monoidk._, legacy._
+
+class MonoidKTests extends KittensSuite {
+  import SemigroupKTests.ComplexProduct
+
+  val m = MonoidK[ComplexProduct].algebra[Char]
+  checkAll("MonoidK[ComplexProduct]", GroupLaws[ComplexProduct[Char]].monoid(m))
+}

--- a/core/src/test/scala/cats/derived/semigroupk.scala
+++ b/core/src/test/scala/cats/derived/semigroupk.scala
@@ -1,0 +1,62 @@
+/*
+ * Copyright (c) 2016 Miles Sabin
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package cats.derived
+
+import cats._, instances.all._, kernel.laws.GroupLaws
+import org.scalacheck.Arbitrary, Arbitrary.arbitrary
+
+import semigroupk._, legacy._
+
+class SemigroupKTests extends KittensSuite {
+  import SemigroupKTests.ComplexProduct
+
+  val sg = SemigroupK[ComplexProduct].algebra[Char]
+  checkAll("SemigroupK[ComplexProduct]", GroupLaws[ComplexProduct[Char]].semigroup(sg))
+}
+
+object SemigroupKTests {
+
+  case class ComplexProduct[T](
+    lbl: String,          // MkSemigroup.const
+    set: Set[T],          // provided
+    fns: Vector[() => T], // MkSemigroup.composedd
+    opt: Eval[Option[T]]) // MkSemigroup.applied
+
+  object ComplexProduct {
+    implicit def arb[T: Arbitrary]: Arbitrary[ComplexProduct[T]] =
+      Arbitrary(for {
+        lbl <- arbitrary[String]
+        set <- arbitrary[Set[T]]
+        vec <- arbitrary[Vector[T]]
+        fns = vec.map(x => () => x)
+        opt <- arbitrary[Option[T]]
+      } yield ComplexProduct(lbl, set, fns, Eval.now(opt)))
+
+    implicit def eqv[T: Eq]: Eq[ComplexProduct[T]] =
+      new Eq[ComplexProduct[T]] {
+        val eqSet = Eq[Set[T]]
+        val eqVec = Eq[Vector[T]]
+        val eqOpt = Eq[Eval[Option[T]]]
+
+        def eqv(x: ComplexProduct[T], y: ComplexProduct[T]) =
+          x.lbl == y.lbl &&
+            eqSet.eqv(x.set, y.set) &&
+            eqVec.eqv(x.fns.map(_()), y.fns.map(_())) &&
+            eqOpt.eqv(x.opt, y.opt)
+      }
+  }
+}


### PR DESCRIPTION
I took the standalone approach in `MkMonoidK` for two reasons:

1. Faster compilation
2. `MkEmptyK[O[I[?]]]` and `MkSemigroupK[O[I[?]]]` can derive instances that taken together don't form a `MonoidK[O[I[?]]]`. E.g. consider `NonEmptyList[Option[?]]`