### PR TITLE
Bump export-hook version to 1.2.0

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -30,8 +30,8 @@ lazy val commonSettings = Seq(
     "org.typelevel"  %% "cats"           % "0.9.0",
     "org.typelevel"   %% "alleycats-core" % "0.1.9",
     "com.chuusai"     %% "shapeless"      % "2.3.2",
-    "org.typelevel"   %% "export-hook"    % "1.1.0",
-    "org.scalatest"   %% "scalatest"      % "3.0.0" % "test",
+    "org.typelevel"   %% "export-hook"    % "1.2.0",
+    "org.scalatest"   %% "scalatest"      % "3.0.1" % "test",
     "org.scalacheck"  %% "scalacheck"     % "1.13.4" % "test",
     "org.typelevel"   %% "discipline"     % "0.7.3" % "test",
     compilerPlugin("org.spire-math" %% "kind-projector" % "0.9.3")


### PR DESCRIPTION
... as per [this](https://gitter.im/milessabin/export-hook?at=58a212624150746b1513a5a7) message by @kailuowang.

> The dependency on export-hook 1.1.0 should’ve been evicted to 1.2.0 by Alleycats. (at least that’s how kittens build passed). Of course it’s a mistake on my side to leave that export-hook version at 1.1.0 in kittens.

Also, bump scalatest to 3.0.1 just because we can :)