### PR TITLE
SBT 0.13.13-M1 -> 0.13.13, CrossVersion.full -> CrossVersion.patch for Typelevel Scala compatibility.

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,10 +114,10 @@ using Typelevel Scala and see if it resolves the issue.
 
 To use Typelevel Scala you should,
 
-+ Update your `project/build.properties` to require SBT 0.13.13-M1 or later,
++ Update your `project/build.properties` to require SBT 0.13.13 or later,
 
   ```
-  sbt.version=0.13.13-M1
+  sbt.version=0.13.13
   ```
 
 + Add the following to your `build.sbt` immediately next to where you set `scalaVersion`,

--- a/build.sbt
+++ b/build.sbt
@@ -37,7 +37,7 @@ lazy val commonSettings = Seq(
     compilerPlugin("org.spire-math" %% "kind-projector" % "0.9.3")
   ) ++ (CrossVersion.partialVersion(scalaVersion.value) match {
     case Some((2, scalaMajor)) if scalaMajor < 12 =>
-      Seq(compilerPlugin("com.milessabin" % "si2712fix-plugin" % "1.1.0" cross CrossVersion.full))
+      Seq(compilerPlugin("com.milessabin" % "si2712fix-plugin" % "1.1.0" cross CrossVersion.patch))
     case _ => Seq()
   }),
 
@@ -93,7 +93,7 @@ addCommandAlias("root", ";project root")
 lazy val scalaMacroDependencies: Seq[Setting[_]] = Seq(
   libraryDependencies ++= Seq(
     "org.scala-lang" % "scala-reflect" % scalaVersion.value % "provided",
-    compilerPlugin("org.scalamacros" % "paradise" % "2.1.0" cross CrossVersion.full)
+    compilerPlugin("org.scalamacros" % "paradise" % "2.1.0" cross CrossVersion.patch)
   )
 )
 

--- a/build.sbt
+++ b/build.sbt
@@ -92,7 +92,7 @@ addCommandAlias("root", ";project root")
 
 lazy val scalaMacroDependencies: Seq[Setting[_]] = Seq(
   libraryDependencies ++= Seq(
-    "org.scala-lang" % "scala-reflect" % scalaVersion.value % "provided",
+    scalaOrganization.value % "scala-reflect" % scalaVersion.value % "provided",
     compilerPlugin("org.scalamacros" % "paradise" % "2.1.0" cross CrossVersion.patch)
   )
 )

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.13-M1
+sbt.version=0.13.13


### PR DESCRIPTION
Addressing the issue described at [typelevel/scala#135](https://github.com/typelevel/scala/issues/135). Moved to SBT version 0.13.13 from 0.13.13-M1, set CrossVersion.patch from CrossVersion.full, and set scalaOrganization.value from "org.scala-lang" in library dependencies.