### PR TITLE
Add generic derivation for Show (solves #40 with a known limitation)

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -2,3 +2,4 @@ Cody Allen <ceedubs@gmail.com> @fourierstrick
 Kailuo Wang <kailuo.wang@gmail.com> @kailuowang
 Miles Sabin <miles@milessabin.com> @milessabin
 Georgi Krastev <joro.kr.21@gmail.com> @Joro_Kr
+Fabio Labella <fabio.labella2@gmail.com> @SystemFw

--- a/README.md
+++ b/README.md
@@ -155,4 +155,5 @@ kittens is built with SBT 0.13.9 or later, and its master branch is built with S
 + Kailuo Wang <kailuo.wang@gmail.com> [@kailuowang](https://twitter.com/kailuowang)
 + Miles Sabin <miles@milessabin.com> [@milessabin](https://twitter.com/milessabin)
 + Georgi Krastev <joro.kr.21@gmail.com> [@Joro_Kr](https://twitter.com/joro_kr)
++ Fabio Labella <fabio.labella2@gmail.com> [@SystemFw]()
 + Your name here :-)

--- a/core/src/main/scala/cats/derived/show.scala
+++ b/core/src/main/scala/cats/derived/show.scala
@@ -1,0 +1,68 @@
+package cats.derived
+
+import cats.Show
+import export.{ exports, reexports }
+import shapeless._, labelled._
+
+@reexports[MkShow]
+object show
+
+/**
+ * Due to a limitation in the way Shapeless' `describe` is currently
+ * implemented, `Show` can't be derived for ADTs which are _both_
+ * recursive _and_ generic in one or more type parameters. 
+ * 
+ * See the test suite for more precise examples of what can and cannot
+ * be derived.
+ */
+trait MkShow[A] extends Show[A]
+
+@exports
+object MkShow {
+  private def instance[A](body: A => String) = new Show[A] {
+    def show(value: A): String = body(value)
+  }
+
+  implicit def emptyProductDerivedShow: Show[HNil] =
+    instance(_ => "")
+
+  implicit def productDerivedShow[K <: Symbol, V, T <: HList](
+      implicit key: Witness.Aux[K],
+      showV: Lazy[Show[V]],
+      showT: Show[T]): Show[FieldType[K, V] :: T] = instance { fields =>
+    val fieldName = key.value.name
+    val fieldValue = showV.value.show(fields.head)
+    val nextFields = showT.show(fields.tail)
+
+    if (nextFields.isEmpty)
+      s"$fieldName = $fieldValue"
+    else
+      s"$fieldName = $fieldValue, $nextFields"
+  }
+
+  implicit def emptyCoproductDerivedShow: Show[CNil] =
+    sys.error("Kittens derived Show instance: impossible to call `show` on `CNil`")
+
+  implicit def coproductDerivedShow[K <: Symbol, V, T <: Coproduct](
+      implicit key: Witness.Aux[K],
+      showV: Lazy[Show[V]],
+      showT: Lazy[Show[T]]): Show[FieldType[K, V] :+: T] = instance {
+    case Inl(l) => showV.value.show(l)
+    case Inr(r) => showT.value.show(r)
+  }
+
+  implicit def genericDerivedShowProduct[A, R <: HList](
+      implicit repr: LabelledGeneric.Aux[A, R],
+      t: Lazy[Typeable[A]],
+      s: Lazy[Show[R]]): Show[A] = instance { a =>
+    val name = t.value.describe.takeWhile(_ != '[')
+    val contents = s.value.show(repr.to(a))
+
+    s"$name($contents)"
+  }
+
+  implicit def genericDerivedShowCoproduct[A, R <: Coproduct](
+      implicit repr: LabelledGeneric.Aux[A, R],
+      s: Lazy[Show[R]]): Show[A] =
+    instance(a => s.value.show(repr.to(a)))
+}

--- a/core/src/main/scala/cats/derived/show.scala
+++ b/core/src/main/scala/cats/derived/show.scala
@@ -10,8 +10,12 @@ object show
 /**
  * Due to a limitation in the way Shapeless' `describe` is currently
  * implemented, `Show` can't be derived for ADTs which are _both_
- * recursive _and_ generic in one or more type parameters. 
- * 
+ * recursive _and_ generic in one or more type parameters.
+ *
+ * See:
+ * https://github.com/milessabin/kittens/pull/48#issue-249836267
+ * https://github.com/milessabin/shapeless/issues/750
+ *
  * See the test suite for more precise examples of what can and cannot
  * be derived.
  */

--- a/core/src/test/scala/cats/derived/adtdefns.scala
+++ b/core/src/test/scala/cats/derived/adtdefns.scala
@@ -58,6 +58,16 @@ object TestDefns {
 
   final case class Foo(i: Int, b: Option[String])
 
+  case class Inner(i: Int)
+  case class Outer(in: Inner)
+
+  sealed trait IntTree
+  final case class IntLeaf(t: Int) extends IntTree
+  final case class IntNode(l: IntTree, r: IntTree) extends IntTree
+
+  sealed trait GenericAdt[T]
+  case class GenericAdtCase[T](v: Option[T]) extends GenericAdt[T]
+
   implicit val arbFoo: Arbitrary[Foo] =
     Arbitrary(for {
       i <- arbitrary[Int]

--- a/core/src/test/scala/cats/derived/show.scala
+++ b/core/src/test/scala/cats/derived/show.scala
@@ -1,0 +1,55 @@
+package cats.derived
+
+import cats.Show
+import cats.instances.all._
+import shapeless.test.illTyped
+
+import MkShow._
+import TestDefns._
+
+class ShowTests extends KittensSuite {
+  test("Simple case classes") {
+    val foo = Foo(42, Option("Hello"))
+    val printedFoo = "Foo(i = 42, b = Some(Hello))"
+
+    assert(foo.show == printedFoo)
+  }
+
+  test("Nested case classes") {
+    val nested = Outer(Inner(3))
+    val printedNested = "Outer(in = Inner(i = 3))"
+
+    assert(nested.show == printedNested)
+  }
+
+  test("Recursive ADTs with no type parameters") {
+    val tree: IntTree = IntNode(IntLeaf(1), IntNode(IntNode(IntLeaf(2), IntLeaf(3)), IntLeaf(4)))
+    val printedTree =
+      "IntNode(l = IntLeaf(t = 1), r = IntNode(l = IntNode(l = IntLeaf(t = 2), r = IntLeaf(t = 3)), r = IntLeaf(t = 4)))"
+
+    assert(tree.show == printedTree)
+  }
+
+  test("Non recursive ADTs with type parameters") {
+    val genAdt: GenericAdt[Int] = GenericAdtCase(Some(1))
+    val printedGenAdt = "GenericAdtCase(v = Some(1))"
+
+    assert(genAdt.show == printedGenAdt)
+  }
+
+  test("Recursive ADTs with type parameters are not supported") {
+    val tree: Tree[Int] = Node(Leaf(1), Node(Node(Leaf(2), Leaf(3)), Leaf(4)))
+    val printedTree =
+      "Node(l = Leaf(t = 1), r = Node(l = Node(l = Leaf(t = 2), r = Leaf(t = 3)), r = Leaf(t = 4)))"
+
+    illTyped("Show[Tree[Int]]")
+  }
+
+  test("existing Show instances in scope are respected") {
+    implicit def showInt: Show[Foo] = new Show[Foo] {
+      def show(foo: Foo) = ""
+    }
+
+    assert(Foo(42, Option("Hello")).show == "")
+  }
+}


### PR DESCRIPTION
This PR add generic derivation for `Show`, with the limitation that it doesn't work for ADTs which are _both_ recursive _and_ generic in one or more type parameters.

This is due to the way Shapeless `describe` is currently implemented: since `Typeable` instances have to be able to cast, they happen to have stricter constraints than what's needed for this use case of  `describe`. I don't think the limitation in this PR can be overcome short of splitting `describe` out of `Typeable`

@kailuowang The only thing I can't understand: in my tests, `import show._` doesn't work, I have to do `import MkShow._`. Since I've never used export hook, could you take a look and see if everything is okay on that front?