### PR TITLE
New resolution

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,12 +50,26 @@ res0: Cat[Int] = Cat(2,List(3, 4))
 #### Derive `Show`
 
 ```scala
-scala> implicit val cs = cats.derive.show[Cat[Int]]
-catShow: cats.Show[Cat[Int]] = cats.derived.MkShow3$$anon$1@7ec30e6b
 
-scala> cat.show
-res1: String = Cat(food = 1, foods = List(2, 3))
+scala> case class Address(street: String, city: String, state: String)
+scala> case class ContactInfo(phoneNumber: String, address: Address)
+scala> case class People(name: String, contactInfo: ContactInfo)
+
+scala> val mike = People("Mike", ContactInfo("202-295-3928", Address("1 Main ST", "Chicago", "IL")))
+scala> import cats._,cats.implicits._
+
+scala> //existing show instance for Address
+scala> implicit val addressShow: Show[Address] = new Show[Address]{ 
+          def show(a: Address) = s"${a.street}, ${a.city}, ${a.state}" 
+       }  //existing show instance for Address
+
+scala> implicit val peopleShow = derive.show[People] //auto derive Show for People
+
+scala> mike.show
+res0: String = People(name = Mike, contactInfo = ContactInfo(phoneNumber = 202-295-3928, address = 1 Main ST, Chicago, IL))
+
 ```
+Note that in this example, the derivation auto derived all referenced class but still respect the existing instance in scope. 
 
 ### Sequence examples
 Note that to run these examples you need on partial unification to overcome [SI-2712](https://github.com/scala/bug/issues/2712). An easy way to achieve that is to use this [sbt-plugin](https://github.com/fiadliel/sbt-partial-unification), add to your `project/plugs.sbt`:

--- a/README.md
+++ b/README.md
@@ -58,10 +58,10 @@ scala> case class People(name: String, contactInfo: ContactInfo)
 scala> val mike = People("Mike", ContactInfo("202-295-3928", Address("1 Main ST", "Chicago", "IL")))
 scala> import cats._,cats.implicits._
 
-scala> //existing show instance for Address
-scala> implicit val addressShow: Show[Address] = new Show[Address]{ 
+scala> //existing Show instance for Address
+scala> implicit val addressShow: Show[Address] = new Show[Address] {
           def show(a: Address) = s"${a.street}, ${a.city}, ${a.state}" 
-       }  //existing show instance for Address
+       }
 
 scala> implicit val peopleShow = derive.show[People] //auto derive Show for People
 

--- a/core/src/main/scala/cats/derive.scala
+++ b/core/src/main/scala/cats/derive.scala
@@ -1,9 +1,10 @@
 package cats
-import alleycats.{EmptyK, Pure}
+import alleycats.{Empty, EmptyK, Pure}
 import cats.derived._
 
 object derive {
   def functor[F[_]](implicit F: MkFunctor[F]) : Functor[F] = F
+  def empty[A](implicit A: MkEmpty[A]): Empty[A] = A
   def emptyK[F[_]](implicit F: MkEmptyK[F]): EmptyK[F] = F
   def eq[T](implicit F: MkEq[T]): Eq[T] = F
   def foldable[F[_]](implicit F: MkFoldable[F]): Foldable[F] = F

--- a/core/src/main/scala/cats/derived/eq.scala
+++ b/core/src/main/scala/cats/derived/eq.scala
@@ -26,33 +26,48 @@ object MkEq extends MkEqDerivation {
   def apply[T](implicit met: MkEq[T]): MkEq[T] = met
 }
 
-trait MkEqDerivation {
+private[derived] abstract class MkEqDerivation extends MkEq0 {
   implicit val mkEqHnil: MkEq[HNil] =
     new MkEq[HNil] {
       def eqv(a: HNil, b: HNil) = true
     }
 
-  implicit def mkEqHcons[H, T <: HList](implicit eqH: Lazy[Eq[H]], eqT: Lazy[MkEq[T]]): MkEq[H :: T] =
-    new MkEq[H :: T] {
-      def eqv(a: H :: T, b: H :: T) = eqH.value.eqv(a.head, b.head) && eqT.value.eqv(a.tail, b.tail)
-    }
+  implicit def mkEqHcons[H, T <: HList](implicit eqH: Eq[H], eqT: MkEq[T]): MkEq[H :: T] =
+    mkEqHconsBase(eqH, eqT)
 
   implicit val mkEqCnil: MkEq[CNil] =
     new MkEq[CNil] {
       def eqv(a: CNil, b: CNil) = true
     }
 
-  implicit def mkEqCcons[L, R <: Coproduct](implicit eqL: Lazy[Eq[L]], eqR: Lazy[MkEq[R]]): MkEq[L :+: R] =
-    new MkEq[L :+: R] {
-      def eqv(a: L :+: R, b: L :+: R) = (a, b) match {
-        case (Inl(l1), Inl(l2)) => eqL.value.eqv(l1, l2)
-        case (Inr(r1), Inr(r2)) => eqR.value.eqv(r1, r2)
-        case _ => false
-      }
-    }
+  implicit def mkEqCcons[L, R <: Coproduct](implicit eqL: Eq[L], eqR: MkEq[R]): MkEq[L :+: R] = mkEqCconsBase(eqL, eqR)
+
 
   implicit def mkEqGeneric[T, R](implicit gen: Generic.Aux[T, R], eqR: Lazy[MkEq[R]]): MkEq[T] =
     new MkEq[T] {
       def eqv(a: T, b: T) = eqR.value.eqv(gen.to(a), gen.to(b))
     }
+}
+
+private[derived] abstract class MkEq0 {
+
+  implicit def mkEqHconsFurther[H, T <: HList](implicit eqH: Lazy[MkEq[H]], eqT: MkEq[T]): MkEq[H :: T] = mkEqHconsBase(eqH.value, eqT)
+
+  protected def mkEqHconsBase[H, T <: HList](eqH: Eq[H], eqT: MkEq[T]): MkEq[H :: T] =
+    new MkEq[H :: T] {
+      def eqv(a: H :: T, b: H :: T) = eqH.eqv(a.head, b.head) && eqT.eqv(a.tail, b.tail)
+    }
+
+  implicit def mkEqCconsFurther[L, R <: Coproduct](implicit eqL: Lazy[MkEq[L]], eqR: MkEq[R]): MkEq[L :+: R] = mkEqCconsBase(eqL.value, eqR)
+
+  protected def mkEqCconsBase[L, R <: Coproduct](eqL: Eq[L], eqR: MkEq[R]): MkEq[L :+: R] =
+    new MkEq[L :+: R] {
+      def eqv(a: L :+: R, b: L :+: R) = (a, b) match {
+        case (Inl(l1), Inl(l2)) => eqL.eqv(l1, l2)
+        case (Inr(r1), Inr(r2)) => eqR.eqv(r1, r2)
+        case _ => false
+      }
+    }
+
+
 }

--- a/core/src/main/scala/cats/derived/functor.scala
+++ b/core/src/main/scala/cats/derived/functor.scala
@@ -59,7 +59,7 @@ trait MkFunctorDerivation extends MkFunctor1 {
 
 trait MkFunctor1 extends MkFunctor2 {
   // Further induction step for products todo: de-duplicate the code from the above induction with instance in scope
-  implicit def mkFunctorHconsFurtherDerive[F[_]](implicit ihc: IsHCons1[F, MkFunctor, MkFunctor]): MkFunctor[F] =
+  implicit def mkFunctorHconsFurther[F[_]](implicit ihc: IsHCons1[F, MkFunctor, MkFunctor]): MkFunctor[F] =
     new MkFunctor[F] {
       def safeMap[A, B](fa: F[A])(f: A => Eval[B]): Eval[F[B]] = {
         import ihc._
@@ -72,7 +72,7 @@ trait MkFunctor1 extends MkFunctor2 {
     }
 
   // Futher induction step for coproducts
-  implicit def mkFunctorCconsFurtherDerive[F[_]](implicit icc: IsCCons1[F, MkFunctor, MkFunctor]): MkFunctor[F] =
+  implicit def mkFunctorCconsFurther[F[_]](implicit icc: IsCCons1[F, MkFunctor, MkFunctor]): MkFunctor[F] =
     new MkFunctor[F] {
       def safeMap[A, B](fa: F[A])(f: A => Eval[B]): Eval[F[B]] = {
         import icc._

--- a/core/src/main/scala/cats/derived/functor.scala
+++ b/core/src/main/scala/cats/derived/functor.scala
@@ -58,6 +58,33 @@ trait MkFunctorDerivation extends MkFunctor1 {
 }
 
 trait MkFunctor1 extends MkFunctor2 {
+  // Further induction step for products todo: de-duplicate the code from the above induction with instance in scope
+  implicit def mkFunctorHconsFurtherDerive[F[_]](implicit ihc: IsHCons1[F, MkFunctor, MkFunctor]): MkFunctor[F] =
+    new MkFunctor[F] {
+      def safeMap[A, B](fa: F[A])(f: A => Eval[B]): Eval[F[B]] = {
+        import ihc._
+        val (hd, tl) = unpack(fa)
+        for {
+          fhd <- fh.safeMap(hd)(f)
+          ftl <- ft.safeMap(tl)(f)
+        } yield pack(fhd, ftl)
+      }
+    }
+
+  // Futher induction step for coproducts
+  implicit def mkFunctorCconsFurtherDerive[F[_]](implicit icc: IsCCons1[F, MkFunctor, MkFunctor]): MkFunctor[F] =
+    new MkFunctor[F] {
+      def safeMap[A, B](fa: F[A])(f: A => Eval[B]): Eval[F[B]] = {
+        import icc._
+        unpack(fa) match {
+          case Left(hd)  => fh.safeMap(hd)(f).map { fhd => pack(Left(fhd)) }
+          case Right(tl) => ft.safeMap(tl)(f).map { ftl => pack(Right(ftl)) }
+        }
+      }
+    }
+}
+
+trait MkFunctor2 extends MkFunctor3 {
   implicit def mkFunctorSplit[F[_]](implicit split: Split1[F, Functor, Functor]): MkFunctor[F] =
     new MkFunctor[F] {
       def safeMap[A, B](fa: F[A])(f: A => Eval[B]): Eval[F[B]] = {
@@ -67,7 +94,7 @@ trait MkFunctor1 extends MkFunctor2 {
     }
 }
 
-trait MkFunctor2 extends MkFunctor3 {
+trait MkFunctor3 extends MkFunctor4 {
   implicit def mkFunctorGeneric[F[_]](implicit gen: Generic1[F, MkFunctor]): MkFunctor[F] =
     new MkFunctor[F] {
       def safeMap[A, B](fa: F[A])(f: A => Eval[B]): Eval[F[B]] =
@@ -75,7 +102,7 @@ trait MkFunctor2 extends MkFunctor3 {
     }
 }
 
-trait MkFunctor3 {
+trait MkFunctor4 {
   implicit def mkFunctorConstFunctor[T]: MkFunctor[Const[T]#λ] =
     new MkFunctor[Const[T]#λ] {
       def safeMap[A, B](t: T)(f: A => Eval[B]): Eval[T] = now(t)

--- a/core/src/main/scala/cats/derived/functor.scala
+++ b/core/src/main/scala/cats/derived/functor.scala
@@ -30,7 +30,7 @@ object MkFunctor extends MkFunctorDerivation {
   def apply[F[_]](implicit mff: MkFunctor[F]): MkFunctor[F] = mff
 }
 
-trait MkFunctorDerivation extends MkFunctor1 {
+private[derived] abstract class MkFunctorDerivation extends MkFunctor1 {
   // Induction step for products
   implicit def mkFunctorHcons[F[_]](implicit ihc: IsHCons1[F, Functor, MkFunctor]): MkFunctor[F] =
     new MkFunctor[F] {
@@ -57,7 +57,7 @@ trait MkFunctorDerivation extends MkFunctor1 {
     }
 }
 
-trait MkFunctor1 extends MkFunctor2 {
+private[derived] abstract class  MkFunctor1 extends MkFunctor2 {
   // Further induction step for products todo: de-duplicate the code from the above induction with instance in scope
   implicit def mkFunctorHconsFurther[F[_]](implicit ihc: IsHCons1[F, MkFunctor, MkFunctor]): MkFunctor[F] =
     new MkFunctor[F] {
@@ -84,7 +84,7 @@ trait MkFunctor1 extends MkFunctor2 {
     }
 }
 
-trait MkFunctor2 extends MkFunctor3 {
+private[derived] abstract class  MkFunctor2 extends MkFunctor3 {
   implicit def mkFunctorSplit[F[_]](implicit split: Split1[F, Functor, Functor]): MkFunctor[F] =
     new MkFunctor[F] {
       def safeMap[A, B](fa: F[A])(f: A => Eval[B]): Eval[F[B]] = {
@@ -94,7 +94,7 @@ trait MkFunctor2 extends MkFunctor3 {
     }
 }
 
-trait MkFunctor3 extends MkFunctor4 {
+private[derived] abstract class  MkFunctor3 extends MkFunctor4 {
   implicit def mkFunctorGeneric[F[_]](implicit gen: Generic1[F, MkFunctor]): MkFunctor[F] =
     new MkFunctor[F] {
       def safeMap[A, B](fa: F[A])(f: A => Eval[B]): Eval[F[B]] =
@@ -102,7 +102,7 @@ trait MkFunctor3 extends MkFunctor4 {
     }
 }
 
-trait MkFunctor4 {
+private[derived] abstract class  MkFunctor4 {
   implicit def mkFunctorConstFunctor[T]: MkFunctor[Const[T]#λ] =
     new MkFunctor[Const[T]#λ] {
       def safeMap[A, B](t: T)(f: A => Eval[B]): Eval[T] = now(t)

--- a/core/src/main/scala/cats/derived/monoid.scala
+++ b/core/src/main/scala/cats/derived/monoid.scala
@@ -25,7 +25,7 @@ object MkMonoid extends MkMonoidDerivation {
   def apply[T](implicit m: MkMonoid[T]): MkMonoid[T] = m
 }
 
-trait MkMonoidDerivation {
+private[derived] abstract class MkMonoidDerivation {
   implicit def mkMonoidAlgebraic[T](implicit e: Lazy[MkEmpty[T]], sg: Lazy[MkSemigroup[T]])
     : MkMonoid[T] = new MkMonoid[T] {
       def empty = e.value.empty

--- a/core/src/main/scala/cats/derived/monoidk.scala
+++ b/core/src/main/scala/cats/derived/monoidk.scala
@@ -21,11 +21,11 @@ import shapeless._
 
 trait MkMonoidK[F[_]] extends MonoidK[F]
 
-object MkMonoidK extends MkMonoidKDerivation {
+object MkMonoidK extends MkMonoidK0 {
   def apply[F[_]](implicit mk: MkMonoidK[F]): MkMonoidK[F] = mk
 }
 
-trait MkMonoidKDerivation extends MkMonoidK0 {
+private[derived] abstract class MkMonoidK0 extends MkMonoidK0b {
   implicit val mkMonoidKHnil: MkMonoidK[Const[HNil]#λ] =
     new MkMonoidK[Const[HNil]#λ] {
       def empty[A] = HNil
@@ -44,7 +44,7 @@ trait MkMonoidKDerivation extends MkMonoidK0 {
     }
 }
 
-trait MkMonoidK0 extends MkMonoidK0a {
+private[derived] abstract class  MkMonoidK0b extends MkMonoidK1 {
   implicit def mkMonoidKHconsFurther[F[_]](implicit ihc: IsHCons1[F, MkMonoidK, MkMonoidK])
   : MkMonoidK[F] = new MkMonoidK[F] {
     import ihc._
@@ -57,7 +57,7 @@ trait MkMonoidK0 extends MkMonoidK0a {
   }
 }
 
-trait MkMonoidK0a extends MkMonoidK1 {
+private[derived] abstract class  MkMonoidK1 extends MkMonoidK1b {
   implicit def mkMonoidKComposed[F[_]](implicit split: Split1[F, MonoidK, Trivial1])
     : MkMonoidK[F] = new MkMonoidK[F] {
       import split._
@@ -67,7 +67,7 @@ trait MkMonoidK0a extends MkMonoidK1 {
     }
 }
 
-trait MkMonoidK1 extends MkMonoidK1a {
+private[derived] abstract class  MkMonoidK1b extends MkMonoidK2 {
   implicit def mkMonoidKComposedFurther[F[_]](implicit split: Split1[F, MkMonoidK, Trivial1])
   : MkMonoidK[F] = new MkMonoidK[F] {
     import split._
@@ -77,7 +77,7 @@ trait MkMonoidK1 extends MkMonoidK1a {
   }
 }
 
-trait MkMonoidK1a extends MkMonoidK2 {
+private[derived] abstract class  MkMonoidK2 extends MkMonoidK2b {
   implicit def mkMonoidKApplicative[F[_]](implicit split: Split1[F, Applicative, MonoidK])
     : MkMonoidK[F] = new MkMonoidK[F] {
       import split._
@@ -87,7 +87,7 @@ trait MkMonoidK1a extends MkMonoidK2 {
     }
 }
 
-trait MkMonoidK2 extends MkMonoidK2a {
+private[derived] abstract class  MkMonoidK2b extends MkMonoidK23 {
   implicit def mkMonoidKApplicativeFurther[F[_]](implicit split: Split1[F, Applicative, MkMonoidK])
   : MkMonoidK[F] = new MkMonoidK[F] {
     import split._
@@ -97,7 +97,7 @@ trait MkMonoidK2 extends MkMonoidK2a {
   }
 }
 
-trait MkMonoidK2a extends MkMonoidK3 {
+private[derived] abstract class  MkMonoidK23 extends MkMonoidK4 {
   implicit def mkMonoidKGeneric[F[_]](implicit gen: Generic1[F, MkMonoidK])
     : MkMonoidK[F] = new MkMonoidK[F] {
       import gen._
@@ -107,7 +107,7 @@ trait MkMonoidK2a extends MkMonoidK3 {
     }
 }
 
-trait MkMonoidK3 {
+private[derived] abstract class  MkMonoidK4 {
   implicit def mkMonoidKConst[T](implicit m: Monoid[T])
     : MkMonoidK[Const[T]#λ] = new MkMonoidK[Const[T]#λ] {
       def empty[A] = m.empty

--- a/core/src/main/scala/cats/derived/package.scala
+++ b/core/src/main/scala/cats/derived/package.scala
@@ -5,16 +5,35 @@ package cats
  * Use cats.derive to explicitly derive instance instead
  */
 package object derived {
+  @deprecated("use cats.derive.emptemptyy instead", "1.0.0-RC1")
   object empty extends MkEmptyDerivation
+
   object emptyK extends MkEmptyKDerivation
+
+  @deprecated("use cats.derive.eq instead", "1.0.0-RC1")
   object eq extends MkEqDerivation
+
   object foldable extends MkFoldableDerivation
+
+  @deprecated("use cats.derive.functor instead", "1.0.0-RC1")
   object functor extends MkFunctorDerivation
+
   object iterable extends IterableDerivationFromMkIterable
+
+  @deprecated("use cats.derive.monoid instead", "1.0.0-RC1")
   object monoid extends MkMonoidDerivation
-  object monoidK extends MkMonoidKDerivation
+
+  @deprecated("use cats.derive.monoidK instead", "1.0.0-RC1")
+  object monoidK extends MkMonoidK0
+
   object pure extends MkPureDerivation
+
+  @deprecated("use cats.derive.semigroup instead", "1.0.0-RC1")
   object semigroup extends MkSemigroupDerivation
-  object semigroupK extends MkSemigroupKDerivation
+
+  @deprecated("use cats.derive.semigroupK instead", "1.0.0-RC1")
+  object semigroupK extends MkSemigroupK0
+
+  @deprecated("use cats.derive.show instead", "1.0.0-RC1")
   object show extends MkShowDerivation
 }

--- a/core/src/main/scala/cats/derived/package.scala
+++ b/core/src/main/scala/cats/derived/package.scala
@@ -5,6 +5,7 @@ package cats
  * Use cats.derive to explicitly derive instance instead
  */
 package object derived {
+  object empty extends MkEmptyDerivation
   object emptyK extends MkEmptyKDerivation
   object eq extends MkEqDerivation
   object foldable extends MkFoldableDerivation

--- a/core/src/main/scala/cats/derived/package.scala
+++ b/core/src/main/scala/cats/derived/package.scala
@@ -5,7 +5,7 @@ package cats
  * Use cats.derive to explicitly derive instance instead
  */
 package object derived {
-  @deprecated("use cats.derive.emptemptyy instead", "1.0.0-RC1")
+  @deprecated("use cats.derive.empty instead", "1.0.0-RC1")
   object empty extends MkEmptyDerivation
 
   object emptyK extends MkEmptyKDerivation

--- a/core/src/main/scala/cats/derived/semigroup.scala
+++ b/core/src/main/scala/cats/derived/semigroup.scala
@@ -26,18 +26,14 @@ object MkSemigroup extends MkSemigroupDerivation {
   def apply[T](implicit met: MkSemigroup[T]): MkSemigroup[T] = met
 }
 
-trait MkSemigroupDerivation {
+private[derived] abstract class MkSemigroupDerivation extends MkSemigroup0{
   implicit val mkSemigroupHnil: MkSemigroup[HNil] =
     new MkSemigroup[HNil] {
       def combine(a: HNil, b: HNil) = HNil
     }
 
-  implicit def mkSemigroupHcons[H, T <: HList](implicit semigroupH: Lazy[Semigroup[H]], semigroupT: Lazy[MkSemigroup[T]]): MkSemigroup[H :: T] =
-    new MkSemigroup[H :: T] {
-      def combine(a: H :: T, b: H :: T) =
-        semigroupH.value.combine(a.head, b.head) :: semigroupT.value.combine(a.tail, b.tail)
-    }
-
+  implicit def mkSemigroupHcons[H, T <: HList](implicit semigroupH: Semigroup[H],
+                                               semigroupT: MkSemigroup[T]): MkSemigroup[H :: T] = mkSemigroupHconsBase
 
   implicit def mkSemigroupGeneric[T, R](
                               implicit gen: Generic.Aux[T, R], semigroupR: Lazy[MkSemigroup[R]]): MkSemigroup[T] =
@@ -45,3 +41,18 @@ trait MkSemigroupDerivation {
       def combine(a: T, b: T) = gen.from(semigroupR.value.combine(gen.to(a), gen.to(b)))
     }
 }
+
+private[derived] abstract class MkSemigroup0 {
+
+  implicit def mkSemigroupHconsFurther[H, T <: HList](implicit semigroupH: Lazy[MkSemigroup[H]], semigroupT: MkSemigroup[T])
+   = mkSemigroupHconsBase(semigroupH.value, semigroupT)
+
+  implicit def mkSemigroupHconsBase[H, T <: HList](implicit semigroupH: Semigroup[H], semigroupT: MkSemigroup[T]):
+    MkSemigroup[H :: T] =
+    new MkSemigroup[H :: T] {
+      def combine(a: H :: T, b: H :: T) =
+        semigroupH.combine(a.head, b.head) :: semigroupT.combine(a.tail, b.tail)
+    }
+
+}
+

--- a/core/src/main/scala/cats/derived/show.scala
+++ b/core/src/main/scala/cats/derived/show.scala
@@ -27,25 +27,25 @@ trait MkShowDerivation extends MkShow0 {
     instance(_ => "")
 
   // used when a Show[V] (a member of the coproduct) is readily available
-  implicit def productDerivedShowWhenShowVAvailable[K <: Symbol, V, T <: HList](
+  implicit def productDerivedShow[K <: Symbol, V, T <: HList](
        implicit key: Witness.Aux[K],
-       showV: Lazy[Show[V]],
+       showV: Show[V],
        showT: MkShow[T]): MkShow[FieldType[K, V] :: T] = mkShowCons
 }
 
 trait MkShow0 extends MkShow1 {
-  // used when a Show[V] (a member of the product) needs to be derived
-  implicit def productDerivedShow[K <: Symbol, V, T <: HList](
+
+  implicit def productDerivedShowFurther[K <: Symbol, V, T <: HList](
        implicit key: Witness.Aux[K],
        showV: Lazy[MkShow[V]],
-       showT: MkShow[T]): MkShow[FieldType[K, V] :: T] = mkShowCons
+       showT: MkShow[T]): MkShow[FieldType[K, V] :: T] = mkShowCons(key, showV.value, showT)
 
   def mkShowCons[K <: Symbol, V, T <: HList](
                                             implicit key: Witness.Aux[K],
-                                            showV: Lazy[Show[V]],
+                                            showV: Show[V],
                                             showT: MkShow[T]): MkShow[FieldType[K, V] :: T] = instance { fields =>
     val fieldName = key.value.name
-    val fieldValue = showV.value.show(fields.head)
+    val fieldValue = showV.show(fields.head)
     val nextFields = showT.show(fields.tail)
 
     if (nextFields.isEmpty)
@@ -63,7 +63,7 @@ trait MkShow1 extends MkShow2 {
   // used when a Show[V] (a member of the coproduct) is readily available
   implicit def coproductDerivedShowWhenShowVAvailable[K <: Symbol, V, T <: Coproduct](
      implicit key: Witness.Aux[K],
-     showV: Lazy[Show[V]],
+     showV: Show[V],
      showT: Lazy[MkShow[T]]): MkShow[FieldType[K, V] :+: T] = mkShowCoproduct
 
 }
@@ -73,13 +73,13 @@ trait MkShow2 extends MkShow3 {
   implicit def coproductDerivedShow[K <: Symbol, V, T <: Coproduct](
      implicit key: Witness.Aux[K],
      showV: Lazy[MkShow[V]],
-     showT: Lazy[MkShow[T]]): MkShow[FieldType[K, V] :+: T] = mkShowCoproduct
+     showT: Lazy[MkShow[T]]): MkShow[FieldType[K, V] :+: T] = mkShowCoproduct(key, showV.value, showT)
 
   def mkShowCoproduct[K <: Symbol, V, T <: Coproduct](
     implicit key: Witness.Aux[K],
-    showV: Lazy[Show[V]],
+    showV: Show[V],
     showT: Lazy[MkShow[T]]): MkShow[FieldType[K, V] :+: T] = instance {
-      case Inl(l) => showV.value.show(l)
+      case Inl(l) => showV.show(l)
       case Inr(r) => showT.value.show(r)
   }
 

--- a/core/src/main/scala/cats/derived/show.scala
+++ b/core/src/main/scala/cats/derived/show.scala
@@ -85,10 +85,10 @@ trait MkShow2 extends MkShow3 {
 
   implicit def genericDerivedShowProduct[A, R <: HList](
                                                          implicit repr: LabelledGeneric.Aux[A, R],
-                                                         t: Lazy[Typeable[A]],
-                                                         s: Lazy[MkShow[R]]): MkShow[A] = instance { a =>
-    val name = t.value.describe.takeWhile(_ != '[')
-    val contents = s.value.show(repr.to(a))
+                                                         t: Typeable[A],
+                                                         s: MkShow[R]): MkShow[A] = instance { a =>
+    val name = t.describe.takeWhile(_ != '[')
+    val contents = s.show(repr.to(a))
 
     s"$name($contents)"
   }

--- a/core/src/test/scala/cats/derived/adtdefns.scala
+++ b/core/src/test/scala/cats/derived/adtdefns.scala
@@ -74,6 +74,22 @@ object TestDefns {
       b <- arbitrary[Option[String]]
     } yield Foo(i, b))
 
+ implicit val arbInner: Arbitrary[Inner] =
+    Arbitrary(for {
+      i <- arbitrary[Int]
+    } yield Inner(i))
+
+ implicit val cogenInner: Cogen[Inner] =
+   Cogen[Int].contramap(_.i)
+
+  implicit val cogenOuter: Cogen[Outer] =
+   Cogen[Inner].contramap(_.in)
+
+ implicit val arbOuter: Arbitrary[Outer] =
+    Arbitrary(for {
+      i <- arbitrary[Inner]
+    } yield Outer(i))
+
   implicit val eqFoo: Eq[Foo] =
     Eq.fromUniversalEquals
 }

--- a/core/src/test/scala/cats/derived/adtdefns.scala
+++ b/core/src/test/scala/cats/derived/adtdefns.scala
@@ -92,4 +92,6 @@ object TestDefns {
 
   implicit val eqFoo: Eq[Foo] =
     Eq.fromUniversalEquals
+
+
 }

--- a/core/src/test/scala/cats/derived/empty.scala
+++ b/core/src/test/scala/cats/derived/empty.scala
@@ -14,16 +14,37 @@
  * limitations under the License.
  */
 
-package cats.derived
+package cats
+package derived
 
 import alleycats.Empty
 import cats.instances.all._
 
-import MkEmpty._
 import TestDefns._
 
 class EmptyTests extends KittensSuite {
   test("for simple product") {
+    implicit val E = derive.empty[Foo]
     assert(Empty[Foo].empty == Foo(0, None))
+  }
+
+  test("for nested product") {
+    implicit val E = derive.empty[Outer]
+    assert(Empty[Outer].empty == Outer(Inner(0)))
+  }
+
+  test("for nested product respect existing instance ") {
+    import InnerEmptyInstance._
+    implicit val E = derive.empty[Outer]
+    assert(Empty[Outer].empty == Outer(Inner(1)))
+  }
+}
+
+
+
+object InnerEmptyInstance {
+
+  implicit def emptyInner: Empty[Inner] = new Empty[Inner]{
+    override def empty: Inner = Inner(1)
   }
 }

--- a/core/src/test/scala/cats/derived/eq.scala
+++ b/core/src/test/scala/cats/derived/eq.scala
@@ -14,11 +14,11 @@
  * limitations under the License.
  */
 
-package cats.derived
+package cats
+package derived
 
 import cats.Eq
 import cats.kernel.laws.OrderLaws
-import eq._
 import org.scalacheck.Prop.forAll
 import org.scalacheck.Arbitrary, Arbitrary.arbitrary
 
@@ -28,11 +28,19 @@ class EqTests extends KittensSuite {
 
   {
     import cats.instances.int._
+    implicit val eqvIList = derive.eq[IList[Int]]
     checkAll("IList[Int]", OrderLaws[IList[Int]].eqv)
   }
+  {
+    import cats.instances.all._
+    implicit val eqvOuter = derive.eq[Outer]
+    checkAll("Outer", OrderLaws[Outer].eqv)
+  }
+
 
   test("IList Eq consistent with universal equality")(check {
     import cats.instances.int._
+    implicit val eqvIList = derive.eq[IList[Int]]
 
     forAll { (a: IList[Int], b: IList[Int]) =>
       Eq[IList[Int]].eqv(a, b) == (a == b)
@@ -45,6 +53,7 @@ class EqTests extends KittensSuite {
     // nasty local implicit Eq instances that think that all things are equal
     implicit def eqInt: Eq[Int] = Eq.instance((_, _) => true)
     implicit def eqOption[A]: Eq[Option[A]] = Eq.instance((_, _) => true)
+    implicit val eqvFoo = derive.eq[Foo]
 
     forAll { (a: Foo, b: Foo) =>
       Eq[Foo].eqv(a, b)

--- a/core/src/test/scala/cats/derived/functor.scala
+++ b/core/src/test/scala/cats/derived/functor.scala
@@ -21,13 +21,20 @@ import cats.Functor
 
 import TestDefns._
 
-import functor._
 import iterable._
 
 class FunctorTests extends KittensSuite {
 
+  test("Functor[GenericAdt] does not conflict with instance in scope") {
+    import cats.instances.option._
+
+    implicit val F = derive.functor[GenericAdt]
+    val g = GenericAdtCase(Some(2))
+    assert(F.map(g)(_ + 1) == GenericAdtCase(Some(3)))
+  }
+
   test("Functor[IList]") {
-    val F = Functor[IList]
+    implicit val F = derive.functor[IList]
 
     // some basic sanity checks
     val lns = (1 to 10).toList
@@ -46,7 +53,7 @@ class FunctorTests extends KittensSuite {
   }
 
   test("Functor[Tree]") {
-    val F = Functor[Tree]
+    implicit val F = derive.functor[Tree]
 
     val tree: Tree[String] =
       Node(
@@ -71,7 +78,7 @@ class FunctorTests extends KittensSuite {
 
   test("Functor[λ[t => List[List[t]]]") {
     type LList[T] = List[List[T]]
-    val F = Functor[LList]
+    implicit val F = derive.functor[LList]
 
     val l = List(List(1), List(2, 3), List(4, 5, 6), List(), List(7))
     val expected = List(List(2), List(3, 4), List(5, 6, 7), List(), List(8))

--- a/core/src/test/scala/cats/derived/monoidk.scala
+++ b/core/src/test/scala/cats/derived/monoidk.scala
@@ -23,6 +23,6 @@ import cats._, instances.all._, kernel.laws.GroupLaws
 class MonoidKTests extends KittensSuite {
   import SemigroupKTests.ComplexProduct
 
-  val m = derive.monoidK[ComplexProduct].algebra[Char]
-  checkAll("MonoidK[ComplexProduct]", GroupLaws[ComplexProduct[Char]].monoid(m))
+  implicit val m = derive.monoidK[ComplexProduct].algebra[Char]
+  checkAll("MonoidK[ComplexProduct]", GroupLaws[ComplexProduct[Char]].monoid)
 }

--- a/core/src/test/scala/cats/derived/monoidk.scala
+++ b/core/src/test/scala/cats/derived/monoidk.scala
@@ -14,15 +14,15 @@
  * limitations under the License.
  */
 
-package cats.derived
+package cats
+package derived
 
 import cats._, instances.all._, kernel.laws.GroupLaws
 
-import monoidK._
 
 class MonoidKTests extends KittensSuite {
   import SemigroupKTests.ComplexProduct
 
-  val m = MonoidK[ComplexProduct].algebra[Char]
+  val m = derive.monoidK[ComplexProduct].algebra[Char]
   checkAll("MonoidK[ComplexProduct]", GroupLaws[ComplexProduct[Char]].monoid(m))
 }

--- a/core/src/test/scala/cats/derived/semigroup.scala
+++ b/core/src/test/scala/cats/derived/semigroup.scala
@@ -14,19 +14,27 @@
  * limitations under the License.
  */
 
-package cats.derived
+package cats
+
+package derived
 
 import cats.Semigroup
-import semigroup._
 import org.scalacheck.Prop.forAll
-import org.scalacheck.Arbitrary, Arbitrary.arbitrary
+import org.scalacheck.Arbitrary
+import Arbitrary.arbitrary
 import TestDefns._
+import cats.kernel.laws.GroupLaws
 
 class SemigroupTests extends KittensSuite {
-  test("for simple product")(check {
-    import cats.instances.all._
-    forAll { (a: Foo, b: Foo) =>
-      Semigroup[Foo].combine(a, b) == Foo(a.i + b.i , Semigroup[Option[String]].combine(a.b,b.b))
-    }
-  })
+  import cats.instances.all._
+  implicit val sFoo = derive.semigroup[Foo]
+  checkAll("Semigroup[Foo]", GroupLaws[Foo].semigroup)
+
+
+  implicit val sOuter = derive.semigroup[Outer]
+
+  implicit val eqOuter: Eq[Outer] = Eq.fromUniversalEquals
+  checkAll("Semigroup[Outer]", GroupLaws[Outer].semigroup)
+
+
 }

--- a/core/src/test/scala/cats/derived/semigroupk.scala
+++ b/core/src/test/scala/cats/derived/semigroupk.scala
@@ -14,7 +14,8 @@
  * limitations under the License.
  */
 
-package cats.derived
+package cats
+package derived
 
 import cats._, instances.all._, kernel.laws.GroupLaws
 import org.scalacheck.Arbitrary, Arbitrary.arbitrary
@@ -24,7 +25,7 @@ import semigroupK._
 class SemigroupKTests extends KittensSuite {
   import SemigroupKTests.ComplexProduct
 
-  val sg = SemigroupK[ComplexProduct].algebra[Char]
+  implicit val sg = derive.semigroupK[ComplexProduct].algebra[Char]
   checkAll("SemigroupK[ComplexProduct]", GroupLaws[ComplexProduct[Char]].semigroup(sg))
 }
 

--- a/core/src/test/scala/cats/derived/semigroupk.scala
+++ b/core/src/test/scala/cats/derived/semigroupk.scala
@@ -20,7 +20,7 @@ package derived
 import cats._, instances.all._, kernel.laws.GroupLaws
 import org.scalacheck.Arbitrary, Arbitrary.arbitrary
 
-import semigroupK._
+
 
 class SemigroupKTests extends KittensSuite {
   import SemigroupKTests.ComplexProduct

--- a/core/src/test/scala/cats/derived/show.scala
+++ b/core/src/test/scala/cats/derived/show.scala
@@ -26,6 +26,16 @@ class ShowTests extends KittensSuite {
     assert(nested.show == printedNested)
   }
 
+  test("respect defined instance") {
+    import InnerInstance._
+    implicit val so = derive.show[Outer]
+
+    val printedNested = "Outer(in = Blah)"
+    val nested = Outer(Inner(3))
+
+    assert(nested.show == printedNested)
+  }
+
   test("Recursive ADTs with no type parameters") {
     implicit val st = derive.show[IntTree]
 
@@ -54,4 +64,10 @@ class ShowTests extends KittensSuite {
     illTyped("Show[Tree[Int]]")
   }
 
+}
+
+object InnerInstance {
+  implicit def showInner: Show[Inner] = new Show[Inner]{
+    def show(t: Inner): String = "Blah"
+  }
 }


### PR DESCRIPTION
These changes will allow semi-automatic derivation for most of the type classes, 
By semi-automatic derivation I mean you would still need to write an explicit derivation for `Foo`, e.g. `implicit val foo = cats.derive.show[Foo]`, but whatever references `Foo` has, their `Show` instances will be automatically derived if not provided in the scope. 
Here is an more detailed example that I added to the README
```scala

scala> case class Address(street: String, city: String, state: String)
scala> case class ContactInfo(phoneNumber: String, address: Address)
scala> case class People(name: String, contactInfo: ContactInfo)
scala> val mike = People("Mike", ContactInfo("202-295-3928", Address("1 Main ST", "Chicago", "IL")))
scala> import cats._,cats.implicits._

scala> //existing show instance for Address
scala> implicit val addressShow: Show[Address] = new Show[Address]{ 
          def show(a: Address) = s"${a.street}, ${a.city}, ${a.state}" 
       }  

scala> implicit val peopleShow = derive.show[People] //auto derive Show for People

scala> mike.show
res0: String = People(name = Mike, contactInfo = ContactInfo(phoneNumber = 202-295-3928, address = 1 Main ST, Chicago, IL))
```

The cost is on the kittens side - I had to duplicated code at several places due to slightly different type signature on things like `IsCCons1` or `Split`, etc.  Maybe we can improve that later.
I also removed several `Lazy` usages.  Should fix #61 