### PR TITLE
Add replicateH

### DIFF
--- a/core/src/main/scala/cats/replicateH/package.scala
+++ b/core/src/main/scala/cats/replicateH/package.scala
@@ -1,0 +1,2 @@
+package cats
+package object replicateH extends ReplicateHOps

--- a/core/src/main/scala/cats/replicateH/replicateH.scala
+++ b/core/src/main/scala/cats/replicateH/replicateH.scala
@@ -1,0 +1,37 @@
+package cats.replicateH
+
+import cats.sequence.Sequencer
+import shapeless._
+import shapeless.ops.hlist._
+
+sealed trait ReplicateH[F[_], N, A] extends Serializable {
+  type Out
+  def apply(fa: F[A]): Out
+}
+
+object ReplicateH {
+  type Aux[F[_], N, A, Out0] = ReplicateH[F, N, A] { type Out = Out0 }
+
+  implicit def mkReplicater[F[_], N, A, L <: HList](
+    implicit
+      filler: Fill.Aux[N, F[A], L],
+      sequencer: Sequencer[L]
+  ): Aux[F, N, A, sequencer.Out] =
+    new ReplicateH[F, N, A] {
+      type Out = sequencer.Out
+      def apply(fa: F[A]): Out = sequencer(filler(fa))
+    }
+}
+
+trait ReplicateHFunctions {
+  def replicateH[F[_], A](n: Nat, fa: F[A])
+    (implicit replicater: ReplicateH[F, n.N, A]): replicater.Out = replicater(fa)
+
+}
+
+trait ReplicateHOps extends {
+  implicit class withReplicateH[F[_], A](self: F[A]) {
+    def replicateH(n: Nat)
+      (implicit replicater: ReplicateH[F, n.N, A]): replicater.Out = replicater(self)
+  }
+}

--- a/core/src/test/scala/cats/replicateH/ReplicateHSuite.scala
+++ b/core/src/test/scala/cats/replicateH/ReplicateHSuite.scala
@@ -1,0 +1,37 @@
+package cats.replicateH
+
+import cats.data._
+import cats.instances.all._
+import cats.laws.discipline.arbitrary._
+
+import shapeless._
+import cats.derived._
+import org.scalacheck.Prop._
+
+
+class ReplicateHSuite extends KittensSuite {
+
+  test("replicating state example")(
+    check {
+      val getAndInc: State[Int, Int] = State { i => (i + 1, i)}
+      val getAndInc5: State[Int, Int :: Int :: Int :: Int :: Int :: HNil] = getAndInc.replicateH(5)
+      getAndInc5.run(0).value ?= (5, 0 :: 1 :: 2 :: 3 :: 4 :: HNil)
+    })
+
+  test("replicating arbitrary state")(check {
+    forAll { (initial: Int, x: State[Int, String]) =>
+      val expected: State[Int, List[String]] = x.replicateA(3)
+      val replicated: State[Int, String :: String :: String :: HNil] = x.replicateH(3)
+      replicated.map(_.toList).run(initial).value ?= expected.run(initial).value
+    }
+  })
+
+  test("replicating arbitrary lists")(check {
+    forAll { (l: List[Long]) =>
+      val expected = l.replicateA(3)
+      val replicated = l.replicateH(3)
+      replicated.map(_.toList) ?= expected
+    }
+  })
+
+}


### PR DESCRIPTION
This adds a `replicateH` method that is similar to the `replicateA`
method from `Applicative` but uses `Nat` and `HList` to return a
statically-sized list as a result.

Example usage:

```scala
scala> import cats.data.State, cats.replicateH._
import cats.data.State
import cats.replicateH._

scala> val getAndInc: State[Int, Int] = State { i => (i + 1, i) }
getAndInc: cats.data.State[Int,Int] = cats.data.IndexedStateT@51106be3

scala> val getAndInc5 = getAndInc.replicateH(5)
getAndInc5: cats.data.IndexedStateT[cats.Eval,Int,Int,Int :: Int :: Int :: Int :: Int :: shapeless.HNil] = cats.data.IndexedStateT@4c29f18c

scala> getAndInc5.map(_.tupled).run(0).value
res1: (Int, (Int, Int, Int, Int, Int)) = (5,(0,1,2,3,4))
```

At work, @randallalexander and I recently wanted something like this
when we had something like an `IO[A]` that represented waiting for a
message and we wanted a convenient API for waiting for `N` messages. I
could also see this being potentially useful on applicative parsers for
when you expect the same input a known number of times.

A few questions:

- Does anyone else think that this would be useful?
- Is there a better name than `replicateH`? (The `H` came from `HList`)
- Would `Sized` be a better result type than `HList` since the elements
are all of the same type? I used `HList` because it would be an extra
step (and I believe an explicit `Functor` constraint) to return `Sized`
instead, and I don't know if people would really want `Sized` instead of
`HList`.