### PR TITLE
Support replicateH on HNil

### DIFF
--- a/core/src/main/scala/cats/replicateH/replicateH.scala
+++ b/core/src/main/scala/cats/replicateH/replicateH.scala
@@ -1,6 +1,5 @@
 package cats.replicateH
 
-import cats.Applicative
 import cats.sequence.Sequencer
 import shapeless._
 import shapeless.ops.hlist._

--- a/core/src/main/scala/cats/sequence/sequence.scala
+++ b/core/src/main/scala/cats/sequence/sequence.scala
@@ -6,7 +6,7 @@
 package cats.sequence
 
 import shapeless._
-import cats.{Apply, Functor}
+import cats.{Applicative, Apply, Functor}
 import shapeless.ops.hlist.{Align, ZipWithKeys}
 import shapeless.ops.record.{Keys, Values}
 
@@ -39,6 +39,15 @@ trait LowPrioritySequencer {
 }
 
 object Sequencer extends LowPrioritySequencer {
+
+  implicit def emptySequencerAux[F0[_], H](implicit F: Applicative[F0])
+    : Aux[HNil, F0, HNil] =
+      new Sequencer[HNil] {
+        type F[X] = F0[X]
+        type LOut = HNil
+
+        def apply(in: HNil): F[HNil] = F.pure(HNil)
+      }
 
   implicit def singleSequencerAux[F0[_], H](implicit F: Functor[F0])
     : Aux[F0[H] :: HNil, F0, H :: HNil] =

--- a/core/src/test/scala/cats/replicateH/ReplicateHSuite.scala
+++ b/core/src/test/scala/cats/replicateH/ReplicateHSuite.scala
@@ -10,10 +10,10 @@ import org.scalacheck.Prop._
 
 
 class ReplicateHSuite extends KittensSuite {
+  val getAndInc: State[Int, Int] = State { i => (i + 1, i)}
 
   test("replicating state example")(
     check {
-      val getAndInc: State[Int, Int] = State { i => (i + 1, i)}
       val getAndInc5: State[Int, Int :: Int :: Int :: Int :: Int :: HNil] = getAndInc.replicateH(5)
       getAndInc5.run(0).value ?= (5, 0 :: 1 :: 2 :: 3 :: 4 :: HNil)
     })
@@ -34,4 +34,33 @@ class ReplicateHSuite extends KittensSuite {
     }
   })
 
+  test("replicate 0 list")(check {
+    forAll { (l: List[Long]) =>
+      val replicated = l.replicateH(0)
+      replicated.map(_.toList) ?= List(Nil)
+    }
+  })
+
+  test("replicate 1 list")(check {
+    forAll { (l: List[Long]) =>
+      val replicated = l.replicateH(1)
+      replicated.map(_.toList) ?= l.map(List(_))
+    }
+  })
+
+  test("replicate 0 state")(
+    check {
+      val getAndInc0: State[Int, HNil] = getAndInc.replicateH(0)
+      forAll { (initial: Int) =>
+        getAndInc0.run(initial).value ?= (initial, HNil)
+      }
+    })
+
+  test("replicate 1 state")(
+    check {
+      val getAndInc1: State[Int, Int :: HNil] = getAndInc.replicateH(1)
+      forAll { (initial: Int) =>
+        getAndInc1.run(initial).value ?= (initial + 1, initial :: HNil)
+      }
+    })
 }

--- a/core/src/test/scala/cats/sequence/SequenceSuite.scala
+++ b/core/src/test/scala/cats/sequence/SequenceSuite.scala
@@ -23,6 +23,13 @@ class SequenceSuite extends KittensSuite {
     }
   })
 
+  test("sequencing HNil with Option")(
+    // We can't simply use HNil.sequence, because F would be ambiguous.
+    // However, we can explicitly grab the Sequencer for Option and use it.
+    check {
+      implicitly[Sequencer.Aux[HNil, Option, HNil]].apply(HNil) == Some(HNil)
+    })
+
   test("sequencing Either")(check {
     forAll { (x: Either[String, Int], y: Either[String, String], z: Either[String, Float]) =>
       val expected = (x, y, z) mapN (_ :: _ :: _ :: HNil)


### PR DESCRIPTION
This changes the `ReplicateH` type class to line up a little better with the
`Sequencer` type class.

This also adds implicit `Sequencer` instances for HNil. One can sequence an
empty `List`, so I can't think of any reason that they shouldn't be able to
sequence an `HNil`. Adding this support allows one to pass zero to `replicateH`.