### PR TITLE
Restore full auto derivation for Empty and Functor

### DIFF
--- a/core/src/main/scala/cats/derived/package.scala
+++ b/core/src/main/scala/cats/derived/package.scala
@@ -1,12 +1,16 @@
 package cats
 
-/**
- * For backward compat purpose.
- * Use cats.derive to explicitly derive instance instead
- */
+import alleycats._
+import shapeless.Refute
+
+/** Full auto derivation of type classes. */
 package object derived {
-  @deprecated("use cats.derive.empty instead", "1.0.0-RC1")
-  object empty extends MkEmptyDerivation
+
+  object empty {
+    implicit def mkEmpty[A](
+      implicit refute: Refute[Empty[A]], empty: MkEmpty[A]
+    ): Empty[A] = empty
+  }
 
   object emptyK extends MkEmptyKDerivation
 

--- a/core/src/main/scala/cats/derived/package.scala
+++ b/core/src/main/scala/cats/derived/package.scala
@@ -19,8 +19,11 @@ package object derived {
 
   object foldable extends MkFoldableDerivation
 
-  @deprecated("use cats.derive.functor instead", "1.0.0-RC1")
-  object functor extends MkFunctorDerivation
+  object functor {
+    implicit def mkFunctor[F[_]](
+      implicit refute: Refute[Functor[F]], functor: MkFunctor[F]
+    ): Functor[F] = functor
+  }
 
   object iterable extends IterableDerivationFromMkIterable
 

--- a/core/src/test/scala/cats/derived/adtdefns.scala
+++ b/core/src/test/scala/cats/derived/adtdefns.scala
@@ -18,6 +18,7 @@ package cats.derived
 
 import cats.Eq
 import org.scalacheck.{Cogen, Arbitrary}, Arbitrary.arbitrary
+import scala.annotation.tailrec
 
 object TestDefns {
   sealed trait IList[A]
@@ -28,9 +29,13 @@ object TestDefns {
     def fromSeq[T](ts: Seq[T]): IList[T] =
       ts.foldRight(INil[T](): IList[T])(ICons(_, _))
 
-    def toList[T](l: IList[T]): List[T] = l match {
-      case INil() => Nil
-      case ICons(h, t) => h :: toList(t)
+    def toList[T](l: IList[T]): List[T] = {
+      @tailrec def loop(il: IList[T], acc: List[T]): List[T] = il match {
+        case INil() => acc.reverse
+        case ICons(h, t) => loop(t, h :: acc)
+      }
+
+      loop(l, Nil)
     }
 
   }

--- a/core/src/test/scala/cats/derived/empty.scala
+++ b/core/src/test/scala/cats/derived/empty.scala
@@ -19,32 +19,49 @@ package derived
 
 import alleycats.Empty
 import cats.instances.all._
-
+import org.scalatest.FreeSpec
 import TestDefns._
 
-class EmptySuite extends KittensSuite {
-  test("for simple product") {
-    implicit val E = derive.empty[Foo]
-    assert(Empty[Foo].empty == Foo(0, None))
+
+class EmptySuite extends FreeSpec {
+
+  "semi auto derivation" - {
+    "for simple product" in {
+      implicit val E = derive.empty[Foo]
+      assert(Empty[Foo].empty == Foo(0, None))
+    }
+
+    "for nested product" in {
+      implicit val E = derive.empty[Outer]
+      assert(Empty[Outer].empty == Outer(Inner(0)))
+    }
+
+    "for nested product respects existing instances" in {
+      import EmptySuite._
+      implicit val E = derive.empty[Outer]
+      assert(Empty[Outer].empty == Outer(Inner(1)))
+    }
   }
 
-  test("for nested product") {
-    implicit val E = derive.empty[Outer]
-    assert(Empty[Outer].empty == Outer(Inner(0)))
-  }
+  "full auto derivation" - {
+    import derived.empty._
 
-  test("for nested product respect existing instance ") {
-    import InnerEmptyInstance._
-    implicit val E = derive.empty[Outer]
-    assert(Empty[Outer].empty == Outer(Inner(1)))
+    "for simple product" in {
+      assert(Empty[Foo].empty == Foo(0, None))
+    }
+
+    "for nested product" in {
+      assert(Empty[Outer].empty == Outer(Inner(0)))
+    }
+
+    "for nested product respects existing instances" in {
+      import EmptySuite._
+      assert(Empty[Outer].empty == Outer(Inner(1)))
+    }
   }
 }
 
-
-
-object InnerEmptyInstance {
-
-  implicit def emptyInner: Empty[Inner] = new Empty[Inner]{
-    override def empty: Inner = Inner(1)
-  }
+object EmptySuite {
+  implicit val emptyInner: Empty[Inner] =
+    Empty(Inner(1))
 }


### PR DESCRIPTION
Using some new combinators from shapeless 2.3.3:
* `OrElse` to prioritize existing instances during derivation
* `Refute` to avoid derivation when an instance exists

Applied successfully to:
- [x] `Empty`
- [x] `Functor`
  
Didn't find a better way to test both semi auto and full auto derivation other than duplicate all tests.