### PR TITLE
(discussion) Yet another idea for auto derivation

### DIFF
--- a/core/src/main/scala/cats/derive.scala
+++ b/core/src/main/scala/cats/derive.scala
@@ -1,9 +1,12 @@
 package cats
-import alleycats.{Empty, EmptyK, Pure}
+
+import alleycats._
 import cats.derived._
+import shapeless.Lazy
+
 
 object derive {
-  def functor[F[_]](implicit F: MkFunctor[F]) : Functor[F] = F
+  def functor[F[_]](implicit F: Lazy[MkFunctor.LowPriority[F]]): Functor[F] = F.value.instance
   def empty[A](implicit A: MkEmpty[A]): Empty[A] = A
   def emptyK[F[_]](implicit F: MkEmptyK[F]): EmptyK[F] = F
   def eq[T](implicit F: MkEq[T]): Eq[T] = F
@@ -13,8 +16,6 @@ object derive {
   def pure[F[_]](implicit F: MkPure[F]): Pure[F] = F
   def semigroup[T](implicit F: MkSemigroup[T]): Semigroup[T] = F
   def semigroupK[F[_]](implicit F: MkSemigroupK[F]): SemigroupK[F] = F
-  def show[T](implicit F: MkShow[T]): Show[T] = F
-
+  def show[A](implicit A: Lazy[MkShow.LowPriority[A]]): Show[A] = A.value.instance
   def iterable[F[_], A](fa: F[A])(implicit mif: MkIterable[F]): Iterable[A] = mif.iterable(fa)
-
 }

--- a/core/src/main/scala/cats/derived/package.scala
+++ b/core/src/main/scala/cats/derived/package.scala
@@ -1,10 +1,10 @@
 package cats
 
-/**
- * For backward compat purpose.
- * Use cats.derive to explicitly derive instance instead
- */
+import shapeless.Lazy
+
+
 package object derived {
+
   @deprecated("use cats.derive.empty instead", "1.0.0-RC1")
   object empty extends MkEmptyDerivation
 
@@ -15,8 +15,11 @@ package object derived {
 
   object foldable extends MkFoldableDerivation
 
-  @deprecated("use cats.derive.functor instead", "1.0.0-RC1")
-  object functor extends MkFunctorDerivation
+  object functor {
+    implicit def derivedFunctor[F[_]](
+      implicit ev: Refute[Functor[F]], F: Lazy[MkFunctor.LowPriority[F]]
+    ): Functor[F] = F.value.instance
+  }
 
   object iterable extends IterableDerivationFromMkIterable
 
@@ -34,6 +37,9 @@ package object derived {
   @deprecated("use cats.derive.semigroupK instead", "1.0.0-RC1")
   object semigroupK extends MkSemigroupK0
 
-  @deprecated("use cats.derive.show instead", "1.0.0-RC1")
-  object show extends MkShowDerivation
+  object show {
+    implicit def derivedShow[A](
+      implicit ev: Refute[Show[A]], A: Lazy[MkShow.LowPriority[A]]
+    ): Show[A] = A.value.instance
+  }
 }

--- a/core/src/main/scala/cats/derived/priority.scala
+++ b/core/src/main/scala/cats/derived/priority.scala
@@ -17,48 +17,85 @@ package cats
 package derived
 
 import shapeless.unexpected
-
 import scala.annotation.implicitNotFound
 
 
 /** The root of the implicit priority hierarchy.
   * Should not be used except as a type parameter bound.
   */
-trait Priority
+trait Priority extends Any
+object Priority {
 
-/** A separate branch of the implicit priority hierarchy.
-  * Enables derived instances to use available instances in scope without causing a cycle.
-  */
-trait Hidden extends Priority
+  /** A separate branch of the implicit priority hierarchy.
+    * Enables derived instances to use available instances in scope without causing a cycle.
+    */
+  trait Hidden extends Priority
 
-/** Lowest priority in the hierarchy. */
-trait LowPriority extends Priority
+  /** Lowest priority in the hierarchy. */
+  trait LowPriority extends Priority
 
-/** The priority of fallback instances defined for any type. */
-trait Default extends LowPriority
+  /** The priority of fallback instances defined for any type. */
+  trait Default extends LowPriority
 
-/** The priority of automatically derived instances. */
-trait Derived extends Default
+  /** The priority of automatically derived instances. */
+  trait Derived extends Default
 
-/** The priority of instances that instantiate higher kinded type classes. */
-trait Instantiated extends Derived
+  /** The priority of instances that instantiate higher kinded type classes. */
+  trait Instantiated extends Derived
 
-/** The priority of instances composed of other type classes. */
-trait Algebraic extends Instantiated
+  /** The priority of instances composed of other type classes. */
+  trait Algebraic extends Instantiated
 
-/** The priority of instances available through subclasses. */
-trait Subclass extends Algebraic
+  /** The priority of instances available through subclasses. */
+  trait Subclass extends Algebraic
 
-/** The priority of ad-hoc instances. */
-trait Orphan extends Subclass
+  /** The priority of ad-hoc instances. */
+  trait Orphan extends Subclass
 
-/** The highest priority in the hierarchy. */
-trait HighPriority extends Orphan
+  /** The highest priority in the hierarchy. */
+  trait HighPriority extends Orphan
+}
+
+
+/** Shorthand aliases for the companion objects of `* -> *` kind type classes. */
+trait Prioritized[F[_]] {
+  type Hidden[A] = F[A] with Priority.Hidden
+  type LowPriority[A] = F[A] with Priority.LowPriority
+  type Default[A] = F[A] with Priority.Default
+  type Derived[A] = F[A] with Priority.Derived
+  type Instantiated[A] = F[A] with Priority.Instantiated
+  type Algebraic[A] = F[A] with Priority.Algebraic
+  type Subclass[A] = F[A] with Priority.Subclass
+  type Orphan[A] = F[A] with Priority.Orphan
+  type HighPriority[A] = F[A] with Priority.HighPriority
+
+  def prioritized[P <: Priority, A](fa: F[A]): F[A] with P =
+    fa.asInstanceOf[F[A] with P]
+}
+
+
+/** Shorthand aliases for the companion objects of `* -> (* -> *)` kind type classes. */
+trait Prioritized1[F[_[_]]] {
+  type Hidden[G[_]] = F[G] with Priority.Hidden
+  type LowPriority[G[_]] = F[G] with Priority.LowPriority
+  type Default[G[_]] = F[G] with Priority.Default
+  type Derived[G[_]] = F[G] with Priority.Derived
+  type Instantiated[G[_]] = F[G] with Priority.Instantiated
+  type Algebraic[G[_]] = F[G] with Priority.Algebraic
+  type Subclass[G[_]] = F[G] with Priority.Subclass
+  type Orphan[G[_]] = F[G] with Priority.Orphan
+  type HighPriority[G[_]] = F[G] with Priority.HighPriority
+
+  def prioritized[P <: Priority, G[_]](fg: F[G]): F[G] with P =
+    fg.asInstanceOf[F[G] with P]
+}
+
 
 /** Proves the absence of an implicit value of type `A`. */
 @implicitNotFound("Could not refute {A}. An implicit instance was found.")
 sealed trait Refute[A]
 object Refute {
+  def apply[A](implicit refute: Refute[A]): Refute[A] = refute
   private val instance: Refute[Any] = new Refute[Any] { }
   implicit def refute[A]: Refute[A] = instance.asInstanceOf[Refute[A]]
   implicit def ambiguous[A](implicit a: A): Refute[A] = unexpected

--- a/core/src/main/scala/cats/derived/priority.scala
+++ b/core/src/main/scala/cats/derived/priority.scala
@@ -1,0 +1,65 @@
+/*
+ * Copyright (c) 2016 Miles Sabin
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package cats
+package derived
+
+import shapeless.unexpected
+
+import scala.annotation.implicitNotFound
+
+
+/** The root of the implicit priority hierarchy.
+  * Should not be used except as a type parameter bound.
+  */
+trait Priority
+
+/** A separate branch of the implicit priority hierarchy.
+  * Enables derived instances to use available instances in scope without causing a cycle.
+  */
+trait Hidden extends Priority
+
+/** Lowest priority in the hierarchy. */
+trait LowPriority extends Priority
+
+/** The priority of fallback instances defined for any type. */
+trait Default extends LowPriority
+
+/** The priority of automatically derived instances. */
+trait Derived extends Default
+
+/** The priority of instances that instantiate higher kinded type classes. */
+trait Instantiated extends Derived
+
+/** The priority of instances composed of other type classes. */
+trait Algebraic extends Instantiated
+
+/** The priority of instances available through subclasses. */
+trait Subclass extends Algebraic
+
+/** The priority of ad-hoc instances. */
+trait Orphan extends Subclass
+
+/** The highest priority in the hierarchy. */
+trait HighPriority extends Orphan
+
+/** Proves the absence of an implicit value of type `A`. */
+@implicitNotFound("Could not refute {A}. An implicit instance was found.")
+sealed trait Refute[A]
+object Refute {
+  private val instance: Refute[Any] = new Refute[Any] { }
+  implicit def refute[A]: Refute[A] = instance.asInstanceOf[Refute[A]]
+  implicit def ambiguous[A](implicit a: A): Refute[A] = unexpected
+}

--- a/core/src/test/scala/cats/derived/functor.scala
+++ b/core/src/test/scala/cats/derived/functor.scala
@@ -20,7 +20,7 @@ package derived
 import cats.Functor
 
 import TestDefns._
-
+import derived.functor._
 import iterable._
 
 class FunctorSuite extends KittensSuite {
@@ -28,13 +28,14 @@ class FunctorSuite extends KittensSuite {
   test("Functor[GenericAdt] does not conflict with instance in scope") {
     import cats.instances.option._
 
-    implicit val F = derive.functor[GenericAdt]
+    MkFunctor[GenericAdt]
+    val F = Functor[GenericAdt]
     val g = GenericAdtCase(Some(2))
     assert(F.map(g)(_ + 1) == GenericAdtCase(Some(3)))
   }
 
   test("Functor[IList]") {
-    implicit val F = derive.functor[IList]
+    val F = Functor[IList]
 
     // some basic sanity checks
     val lns = (1 to 10).toList
@@ -53,7 +54,7 @@ class FunctorSuite extends KittensSuite {
   }
 
   test("Functor[Tree]") {
-    implicit val F = derive.functor[Tree]
+    val F = Functor[Tree]
 
     val tree: Tree[String] =
       Node(
@@ -78,7 +79,7 @@ class FunctorSuite extends KittensSuite {
 
   test("Functor[λ[t => List[List[t]]]") {
     type LList[T] = List[List[T]]
-    implicit val F = derive.functor[LList]
+    val F = Functor[LList]
 
     val l = List(List(1), List(2, 3), List(4, 5, 6), List(), List(7))
     val expected = List(List(2), List(3, 4), List(5, 6, 7), List(), List(8))

--- a/core/src/test/scala/cats/derived/show.scala
+++ b/core/src/test/scala/cats/derived/show.scala
@@ -1,90 +1,110 @@
 package cats
 package derived
 
-import cats.Show
-import cats.instances.all._
-import shapeless.test.illTyped
 import TestDefns._
+import cats.instances.all._
+import cats.syntax.show._
+import shapeless.test.illTyped
+import org.scalatest.FreeSpec
 
-class ShowTests extends KittensSuite {
 
+class ShowSuite extends FreeSpec with SerializableTest {
 
-  test("Simple case classes") {
-    implicit val sf = derive.show[Foo]
-    val foo = Foo(42, Option("Hello"))
-    val printedFoo = "Foo(i = 42, b = Some(Hello))"
-
-    assert(foo.show == printedFoo)
-  }
-
-  test("Nested case classes auto derive inner class") {
-    implicit val so = derive.show[Outer]
-
-    val nested = Outer(Inner(3))
-    val printedNested = "Outer(in = Inner(i = 3))"
-
-    assert(nested.show == printedNested)
-  }
-
-  test("respect defined instance") {
-    import InnerInstance._
-    implicit val so = derive.show[Outer]
-
-    val printedNested = "Outer(in = Blah)"
-    val nested = Outer(Inner(3))
-
-    assert(nested.show == printedNested)
-  }
-
-  test("Recursive ADTs with no type parameters") {
-    implicit val st = derive.show[IntTree]
-
-    val tree: IntTree = IntNode(IntLeaf(1), IntNode(IntNode(IntLeaf(2), IntLeaf(3)), IntLeaf(4)))
-    val printedTree =
-      "IntNode(l = IntLeaf(t = 1), r = IntNode(l = IntNode(l = IntLeaf(t = 2), r = IntLeaf(t = 3)), r = IntLeaf(t = 4)))"
-
-    assert(tree.show == printedTree)
-  }
-
-  test("Non recursive ADTs with type parameters") {
-    implicit val sg = derive.show[GenericAdt[Int]]
-    val genAdt: GenericAdt[Int] = GenericAdtCase(Some(1))
-    val printedGenAdt = "GenericAdtCase(v = Some(1))"
-
-    assert(genAdt.show == printedGenAdt)
-  }
-
-  test("Recursive ADTs with type parameters are not supported") {
-    import cats.derived.show._
-
-    val tree: Tree[Int] = Node(Leaf(1), Node(Node(Leaf(2), Leaf(3)), Leaf(4)))
-    val printedTree =
-      "Node(l = Leaf(t = 1), r = Node(l = Node(l = Leaf(t = 2), r = Leaf(t = 3)), r = Leaf(t = 4)))"
-
-    illTyped("Show[Tree[Int]]")
-  }
-
-  test("Deep type hierarchy") {
-    derive.show[Top]
-    derive.show[People]
-  }
-
-  test("Deep type hierarchy respect existing instance") {
-    implicit val sAdd : Show[Address] = new Show[Address] {
-      def show(t: Address) = t.street + " " + t.city + " " + t.state
+  "derive.show" - {
+    "for simple case classes" in {
+      implicit val sf = derive.show[Foo]
+      val foo = Foo(42, Option("Hello"))
+      val printedFoo = "Foo(i = 42, b = Some(Hello))"
+      assert(foo.show == printedFoo)
     }
-    assert(derive.show[People].show(People(name = "Kai",
-      contactInfo = ContactInfo(
-        phoneNumber = "303-123-4567",
-        address = Address(
-          street = "123 1st St",
-          city = "New York", state = "NY") ))) == "People(name = Kai, contactInfo = ContactInfo(phoneNumber = 303-123-4567, address = 123 1st St New York NY))")
+
+    "for nested case classes" in {
+      implicit val so = derive.show[Outer]
+      val nested = Outer(Inner(3))
+      val printedNested = "Outer(in = Inner(i = 3))"
+      assert(nested.show == printedNested)
+    }
+
+    "respects existing instances" in {
+      import ShowSuite._
+      implicit val so = derive.show[Outer]
+      val printedNested = "Outer(in = Blah)"
+      val nested = Outer(Inner(3))
+      assert(nested.show == printedNested)
+    }
+
+    "for non-generic recursive ADTs" in {
+      implicit val st = derive.show[IntTree]
+      val tree: IntTree = IntNode(IntLeaf(1), IntNode(IntNode(IntLeaf(2), IntLeaf(3)), IntLeaf(4)))
+      val printedTree =
+        "IntNode(l = IntLeaf(t = 1), r = IntNode(l = IntNode(l = IntLeaf(t = 2), r = IntLeaf(t = 3)), r = IntLeaf(t = 4)))"
+      assert(tree.show == printedTree)
+    }
+
+    "for generic non-recursive ADTs" in {
+      implicit val sg = derive.show[GenericAdt[Int]]
+      val genAdt: GenericAdt[Int] = GenericAdtCase(Some(1))
+      val printedGenAdt = "GenericAdtCase(v = Some(1))"
+      assert(genAdt.show == printedGenAdt)
+    }
+
+    "does not support generic recursive ADTs" in {
+      illTyped("derive.show[Tree[Int]]")
+    }
+
+    "for deep type hierarchies" in {
+      derive.show[Top]
+      derive.show[People]
+    }
+
+    "for deep type hierarchies respects existing instances" in {
+      implicit val sAdd : Show[Address] = Show.show { address =>
+        address.street + " " + address.city + " " + address.state
+      }
+
+      assert(derive.show[People].show(People(name = "Kai",
+        contactInfo = ContactInfo(
+          phoneNumber = "303-123-4567",
+          address = Address(
+            street = "123 1st St",
+            city = "New York", state = "NY") ))) ==
+        "People(name = Kai, contactInfo = ContactInfo(phoneNumber = 303-123-4567, address = 123 1st St New York NY))")
+    }
   }
 
+  "derived.show" - {
+    import derived.show._
+
+    "respects existing instances in companion objects" in {
+      import ShowSuite._
+      val b = B(A(42))
+      val printedB = "B(a = an A)"
+      assert(b.show == printedB)
+    }
+
+    "resolves across existing generic instances" in {
+      val genAdt: GenericAdt[Foo] = GenericAdtCase(None)
+      // derive.show prints None.type
+      val printedGenAdt = "GenericAdtCase(v = None)"
+      assert(genAdt.show == printedGenAdt)
+    }
+
+//    "takes priority over fallback instances" in {
+//      import ShowSuite._
+//      assert(Foo(33, Some("kitten")).show == "Foo(i = 33, v = Some(kitten))")
+//    }
+  }
 }
 
-object InnerInstance {
-  implicit def showInner: Show[Inner] = new Show[Inner]{
-    def show(t: Inner): String = "Blah"
+object ShowSuite {
+  implicit def showInner: Show[Inner] = Show.show(_ => "Blah")
+
+//  implicit def showFallback[A]: MkShow.Default[A] =
+//    new MkShow[A](Show.fromToString) with Priority.Default
+
+  case class B(a: A)
+  case class A(i: Int)
+  object A {
+    implicit val showA: Show[A] = Show.show(_ => "an A")
   }
 }


### PR DESCRIPTION
Forgive me for throwing so many different ideas at you :smile: Here is another one:

We can emulate the priority example from scala/scala#6139 with a phantom type parameter like so:
```scala
class MkShow[+P <: Priority, A](val instance: Show[A]) extends AnyVal

trait MkShowDerivation extends MkShow0 {
  def mk[P <: Priority, A](tos: A => String): MkShow[P, A] =
    new MkShow(Show.show(tos))

  implicit def fromShow[T](implicit show: Show[T]): MkShow[Hidden, T] =
    mk(show.show)
}
```

And we can have a `Hidden` priority level that is on a separate branch from other priority levels to break the cycle `Show -> MkShow -> Show -> ...` So now we can enable auto derivation:
```scala
  object show {
    implicit def mkDerivedShow[A](
      implicit ev: Refute[Show[A]], show: MkShow[LowPriority, A]
    ): Show[A] = show.instance
  }
```

`Refute` here makes sure that even instances from companion objects are respected. Users can also provide a fallback instance that has lower priority than `Derived`:
```scala
implicit def fallbackShow[A]: MkShow[Default, A] = MkShow.mk(_.toString)
```

The priority hierarchy here is the same that we had in export-hook.