### PR TITLE
set default project to root

### DIFF
--- a/.sbtrc
+++ b/.sbtrc
@@ -1,1 +1,1 @@
-alias boot = ;reload ;project coreJVM ;iflast shell
+alias boot = ;reload ;project root ;iflast shell


### PR DESCRIPTION
I kept forgetting to use the `releaseAll` alias in kittens. @milessabin can we change the default project back to `root`, it would be a little cumbersome to type `jvm` every sbt session, but it's less surprising. 
