### PR TITLE
Update dep in README to RC3

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ It is available for Scala 2.11 and 2.12, and Scala.js.
 To get started with SBT, simply add the following to your build.sbt file:
 
 ```Scala
-libraryDependencies += "org.typelevel" %% "kittens" % "1.0.0-RC2"
+libraryDependencies += "org.typelevel" %% "kittens" % "1.0.0-RC3"
 ```
 
 [![Build Status](https://api.travis-ci.org/milessabin/kittens.png?branch=master)](https://travis-ci.org/milessabin/kittens)


### PR DESCRIPTION
For some reason RC2 is missing `auto` object when I try to compile - RC3 works fine though.