### PR TITLE
add PartialOrder

### DIFF
--- a/core/src/main/scala/cats/derived/package.scala
+++ b/core/src/main/scala/cats/derived/package.scala
@@ -98,6 +98,12 @@ object cached {
 
   }
 
+  object partialOrder {
+    implicit def kittensMkPartialOrder[A](
+       implicit refute: Refute[PartialOrder[A]], ord: Cached[MkPartialOrder[A]])
+    : PartialOrder[A] = ord.value
+  }
+
   object functor {
     implicit def kittensMkFunctor[F[_]](
       implicit refute: Refute[Functor[F]], ev: Cached[MkFunctor[F]])

--- a/core/src/main/scala/cats/derived/package.scala
+++ b/core/src/main/scala/cats/derived/package.scala
@@ -30,6 +30,12 @@ object auto {
     ): Eq[A] = eq
   }
 
+  object partialOrder {
+    implicit def kittensMkPartialOrder[A](
+      implicit refute: Refute[PartialOrder[A]], ord: MkPartialOrder[A]
+    ): PartialOrder[A] = ord
+  }
+
 
   object functor {
     implicit def kittensMkFunctor[F[_]](
@@ -163,6 +169,8 @@ object semi {
   def emptyK[F[_]](implicit F: MkEmptyK[F]): EmptyK[F] = F
 
   def eq[A](implicit ev: MkEq[A]): Eq[A] = ev
+
+  def partialOrder[A](implicit ev: MkPartialOrder[A]): MkPartialOrder[A] = ev
 
   def functor[F[_]](implicit ev: MkFunctor[F]): Functor[F] = ev
 

--- a/core/src/main/scala/cats/derived/partialOrder.scala
+++ b/core/src/main/scala/cats/derived/partialOrder.scala
@@ -1,0 +1,65 @@
+/*
+ * Copyright (c) 2015 Miles Sabin
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless rorduired by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package cats.derived
+
+import cats.PartialOrder
+import shapeless._
+
+trait MkPartialOrder[T] extends PartialOrder[T]
+
+object MkPartialOrder extends MkPartialOrderDerivation {
+  def apply[T](implicit met: MkPartialOrder[T]): MkPartialOrder[T] = met
+}
+
+private[derived] abstract class MkPartialOrderDerivation {
+  implicit val mkPartialOrderHnil: MkPartialOrder[HNil] =
+    new MkPartialOrder[HNil] {
+      override def partialCompare(x: HNil, y: HNil): Double = 0
+    }
+
+  // Compare product from left to right
+  implicit def mkPartialOrderHcons[H, T <: HList](implicit ordH: PartialOrder[H] OrElse MkPartialOrder[H], ordT: MkPartialOrder[T]): MkPartialOrder[H :: T] =
+    new MkPartialOrder[H :: T] {
+      override def partialCompare(x: H :: T, y: H :: T): Double = {
+        val compareHead = ordH.unify.partialCompare(x.head, y.head)
+        if(compareHead != 0)
+          compareHead
+        else
+          ordT.partialCompare(x.tail, y.tail)
+      }
+    }
+
+  implicit val mkPartialOrderCnil: MkPartialOrder[CNil] =
+    new MkPartialOrder[CNil] {
+      override def partialCompare(x: CNil, y: CNil): Double = 0
+    }
+
+  implicit def mkPartialOrderCcons[L, R <: Coproduct](implicit ordL: PartialOrder[L] OrElse MkPartialOrder[L], ordR: MkPartialOrder[R]): MkPartialOrder[L :+: R] = new MkPartialOrder[L :+: R] {
+    override def partialCompare(x: L :+: R, y: L :+: R): Double = {
+      (x, y) match {
+        case (Inl(l1), Inl(l2)) => ordL.unify.partialCompare(l1, l2)
+        case (Inr(r1), Inr(r2)) => ordR.partialCompare(r1, r2)
+        case _ => Double.NaN
+      }
+    }
+  }
+
+  implicit def mkPartialOrderGeneric[T, R](implicit gen: Generic.Aux[T, R], ordR: Lazy[MkPartialOrder[R]]): MkPartialOrder[T] =
+    new MkPartialOrder[T] {
+      override def partialCompare(x: T, y: T): Double = ordR.value.partialCompare(gen.to(x), gen.to(y))
+    }
+}

--- a/core/src/test/scala/cats/derived/partialOrder.scala
+++ b/core/src/test/scala/cats/derived/partialOrder.scala
@@ -1,0 +1,138 @@
+/*
+ * Copyright (c) 2015 Miles Sabin
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package cats
+package derived
+
+import cats.PartialOrder
+import cats.derived.PartialOrderSuite.Large
+import cats.kernel.laws.discipline._
+import cats.derived.TestDefns.Foo
+import cats.derived.TestDefns.{IList, Outer}
+import org.scalacheck.Prop.forAll
+
+
+class PartialOrderSuite extends KittensSuite {
+  {
+    import auto.partialOrder._
+    import cats.instances.int._
+    checkAll("IList[Int]", PartialOrderTests[IList[Int]].partialOrder)
+  }
+  {
+
+    import auto.partialOrder._
+    import cats.instances.all._
+
+    checkAll("Outer", PartialOrderTests[Outer].partialOrder)
+  }
+
+
+  test("IList PartialOrder consistent with universal equality")(check {
+
+    import auto.partialOrder._
+    import cats.instances.int._
+
+    forAll { (a: IList[Int], b: IList[Int]) =>
+      PartialOrder[IList[Int]].eqv(a, b) == (a == b)
+    }
+  })
+
+
+  test("existing PartialOrder instances in scope are respected")(check {
+
+    import auto.partialOrder._
+    import cats.instances.double._
+
+    // nasty local implicit PartialOrder instances that think that all things are equal
+    implicit def partialOrderInt: PartialOrder[Int] = PartialOrder.from((_, _) => 0)
+    implicit def partialOrderOption[A]: PartialOrder[Option[A]] = PartialOrder.from((_, _) => 0)
+
+    forAll { (a: Foo, b: Foo) =>
+      PartialOrder[Foo].partialCompare(a, b) == 0
+    }
+  })
+
+  test("semi derivation existing PartialOrder instances in scope are respected ")(check {
+
+    import cats.instances.double._
+
+    // nasty local implicit PartialOrder instances that think that all things are equal
+    implicit def partialOrderInt: PartialOrder[Int] = PartialOrder.from((_, _) => 0)
+    implicit def partialOrderOption[A]: PartialOrder[Option[A]] = PartialOrder.from((_, _) => 0)
+
+    implicit val eqF: PartialOrder[Foo] = semi.partialOrder
+
+    forAll { (a: Foo, b: Foo) =>
+      PartialOrder[Foo].partialCompare(a, b) == 0
+    }
+  })
+
+  //compilation time
+  {
+    import auto.partialOrder._
+    import cats.instances.all._
+    semi.partialOrder[Large]
+  }
+}
+
+object PartialOrderSuite{
+  case class Large(
+                    bar1: String,
+                    bar2: Int,
+                    bar3: Boolean,
+                    bar4: Large2,
+                    bar5: List[String],
+                    bar6: Set[Boolean],
+                    bar7: Double,
+                    bar8: Long,
+                    bar9: Char,
+                    bar10: Float,
+                    bar11: String,
+                    bar12: String,
+                    bar13: Boolean,
+                    bar14: Option[String],
+                    bar15: List[String],
+                    bar16: Set[Boolean],
+                    bar17: Double,
+                    bar18: Long,
+                    bar19: Char,
+                    bar20: Float
+                  )
+
+  case class Large2(
+                     bar1: String,
+                     bar2: Int,
+                     bar3: Boolean,
+                     bar4: Option[String],
+                     bar5: List[String],
+                     bar6: Set[Boolean],
+                     bar7: Double,
+                     bar8: Long,
+                     bar9: Char,
+                     bar10: Float,
+                     bar11: String,
+                     bar12: Int,
+                     bar13: Boolean,
+                     bar14: Option[String],
+                     bar15: List[String],
+                     bar16: Set[Boolean],
+                     bar17: Double,
+                     bar18: Long,
+                     bar19: Char,
+                     bar20: Float,
+                     bar21: String
+                   )
+}


### PR DESCRIPTION
For https://github.com/milessabin/kittens/issues/87

Mostly copied `Eq`.

Created https://github.com/milessabin/kittens/pull/90/files#diff-bf34c2a38c2ed0d1879d7c494ef98de3R92 because seems there's no `Order` for `Map[Int, String]`
