### PR TITLE
fix tests

### DIFF
--- a/core/src/test/scala/cats/derived/eq.scala
+++ b/core/src/test/scala/cats/derived/eq.scala
@@ -56,7 +56,7 @@ class EqSuite extends KittensSuite {
   test("existing Eq instances in scope are respected")(check {
 
     import auto.eq._
-    import cats.instances.boolean._
+    import cats.instances.string._ //so that Option instance could be derived
 
     // nasty local implicit Eq instances that think that all things are equal
     implicit def eqInt: Eq[Int] = Eq.instance((_, _) => true)
@@ -69,8 +69,7 @@ class EqSuite extends KittensSuite {
 
   test("semi derivation existing Eq instances in scope are respected ")(check {
 
-
-    import cats.instances.boolean._
+    import cats.instances.string._ //so that Option instance could be derived_
 
     // nasty local implicit Eq instances that think that all things are equal
     implicit def eqInt: Eq[Int] = Eq.instance((_, _) => true)

--- a/core/src/test/scala/cats/derived/order.scala
+++ b/core/src/test/scala/cats/derived/order.scala
@@ -53,7 +53,7 @@ class OrderSuite extends KittensSuite {
   test("existing Order instances in scope are respected")(check {
 
     import auto.order._
-
+    import cats.instances.string._ //so that Option instance could be derived
     // nasty local implicit Order instances that think that all things are equal
     implicit val orderInt: Order[Int] = Order.from((_, _) => 0)
     implicit def orderOption[A]: Order[Option[A]] = Order.from((_, _) => 0)
@@ -64,6 +64,7 @@ class OrderSuite extends KittensSuite {
   })
 
   test("semi derivation existing Order instances in scope are respected ")(check {
+    import cats.instances.string._ //so that Option instance could be derived
     // nasty local implicit Order instances that think that all things are equal
     implicit val orderInt: Order[Int] = Order.from((_, _) => 0)
     implicit def orderOption[A]: Order[Option[A]] = Order.from((_, _) => 0)

--- a/core/src/test/scala/cats/derived/partialOrder.scala
+++ b/core/src/test/scala/cats/derived/partialOrder.scala
@@ -52,7 +52,7 @@ class PartialOrderSuite extends KittensSuite {
   test("existing PartialOrder instances in scope are respected")(check {
 
     import auto.partialOrder._
-    import cats.instances.double._
+    import cats.instances.string._ //so that Option instance could be derived
 
     // nasty local implicit PartialOrder instances that think that all things are equal
     implicit def partialOrderInt: PartialOrder[Int] = PartialOrder.from((_, _) => 0)
@@ -65,7 +65,7 @@ class PartialOrderSuite extends KittensSuite {
 
   test("semi derivation existing PartialOrder instances in scope are respected ")(check {
 
-    import cats.instances.double._
+    import cats.instances.string._ //so that Option instance could be derived
 
     // nasty local implicit PartialOrder instances that think that all things are equal
     implicit def partialOrderInt: PartialOrder[Int] = PartialOrder.from((_, _) => 0)


### PR DESCRIPTION
The original tests were messed up. It should import the string instance so that `Option[String]` instance *could* be derived, the test then provides a "nasty" local `Option[A]` instance that gets used by the derivation. The intention is to test if the local instance bypasses the need to do derivation. 