### PR TITLE
Add ShowPretty derivation

### DIFF
--- a/core/src/main/scala/cats/derived/package.scala
+++ b/core/src/main/scala/cats/derived/package.scala
@@ -62,6 +62,12 @@ object auto {
     ): Show[A] = show
   }
 
+  object showPretty {
+    implicit def kittensMkShowPretty[A](
+     implicit refute: Refute[Show[A]], showPretty: MkShowPretty[A]
+    ): ShowPretty[A] = showPretty
+  }
+
   object monoid extends MkMonoidDerivation //todo the regular approach doesn't work for monoid
 
   object semigroup {
@@ -139,6 +145,12 @@ object cached {
     : Show[A] = ev.value
   }
 
+  object showPretty {
+    implicit def kittensMkShowPretty[A](
+      implicit refute: Refute[Show[A]], ev: Cached[MkShowPretty[A]])
+    : ShowPretty[A] = ev.value
+  }
+
   object monoidK {
     implicit def kittensMkMonoidK[F[_]](
       implicit refute: Refute[MonoidK[F]], ev: Cached[MkMonoidK[F]]
@@ -202,12 +214,14 @@ object semi {
   def partialOrder[A](implicit ev: MkPartialOrder[A]): PartialOrder[A] = ev
 
   def order[A](implicit ev: MkOrder[A]): Order[A] = ev
-  
+
   def hash[A](implicit ev: MkHash[A]): Hash[A] = ev
 
   def functor[F[_]](implicit ev: MkFunctor[F]): Functor[F] = ev
 
   def show[A](implicit ev: MkShow[A]): Show[A] = ev
+
+  def showPretty[A](implicit ev: MkShowPretty[A]): ShowPretty[A] = ev
 
   def foldable[F[_]](implicit F: MkFoldable[F]): Foldable[F] = F
 

--- a/core/src/main/scala/cats/derived/showPretty.scala
+++ b/core/src/main/scala/cats/derived/showPretty.scala
@@ -1,0 +1,84 @@
+package cats.derived
+
+import cats.Show
+import shapeless._
+import shapeless.labelled.FieldType
+
+trait ShowPretty[A] extends Show[A] {
+  def showWithIndent(a: A, indent: Int): String
+  def show(a: A): String = showWithIndent(a, 0)
+}
+
+object ShowPretty {
+  implicit def fromShow[A](implicit s: Show[A]): ShowPretty[A] =
+    new ShowPretty[A] {
+      override def showWithIndent(a: A, indent: Int): String =
+        s.show(a)
+    }
+}
+
+trait MkShowPretty[A] extends ShowPretty[A]
+
+object MkShowPretty extends MkShowPrettyDerivation {
+  def apply[A](implicit showPretty: MkShowPretty[A]): MkShowPretty[A] =
+    showPretty
+}
+
+trait MkShowPrettyDerivation extends MkShowPretty1 {
+  implicit val emptyProductDerivedShowPretty: MkShowPretty[HNil] =
+    instance((_, _) => "")
+
+  implicit def productDerivedShowPretty[K <: Symbol, V, T <: HList](
+      implicit key: Witness.Aux[K],
+      showV: ShowPretty[V] OrElse MkShowPretty[V],
+      showT: MkShowPretty[T]
+  ): MkShowPretty[FieldType[K, V] :: T] = instance { (fields, indent) =>
+    val fieldName = key.value.name
+    val fieldValue = showV.unify.showWithIndent(fields.head, indent)
+    val nextFields = showT.showWithIndent(fields.tail, indent)
+
+    if (nextFields.isEmpty)
+      s"${" " * indent}$fieldName = $fieldValue"
+    else
+      s"${" " * indent}$fieldName = $fieldValue,\n$nextFields"
+  }
+
+  implicit def emptyCoproductDerivedShowPretty: MkShowPretty[CNil] =
+    instance((_, _) => "")
+}
+
+trait MkShowPretty1 extends MkShowPretty2 {
+  implicit def coproductDerivedShowPretty[K <: Symbol, V, T <: Coproduct](
+      implicit key: Witness.Aux[K],
+      showV: ShowPretty[V] OrElse MkShowPretty[V],
+      showT: MkShowPretty[T]
+  ): MkShowPretty[FieldType[K, V] :+: T] = instance {
+    case (Inl(l), indent) => showV.unify.showWithIndent(l, indent)
+    case (Inr(r), indent) => showT.showWithIndent(r, indent)
+  }
+}
+
+trait MkShowPretty2 extends MkShowPretty3 {
+  implicit def genericDerivedShowPrettyProduct[A, R <: HList](
+      implicit repr: LabelledGeneric.Aux[A, R],
+      t: Typeable[A],
+      s: Lazy[MkShowPretty[R]]
+  ): MkShowPretty[A] = instance { (a, indent) =>
+    val name = t.describe.takeWhile(_ != '[')
+    val contents = s.value.showWithIndent(repr.to(a), indent + 2)
+    s"$name(\n$contents\n${" " * indent})"
+  }
+}
+
+trait MkShowPretty3 {
+  protected def instance[A](f: (A, Int) => String): MkShowPretty[A] =
+    new MkShowPretty[A] {
+      def showWithIndent(a: A, indent: Int): String = f(a, indent)
+    }
+
+  implicit def genericDerivedShowPrettyCoproduct[A, R <: Coproduct](
+      implicit repr: LabelledGeneric.Aux[A, R],
+      s: Lazy[MkShowPretty[R]]
+  ): MkShowPretty[A] =
+    instance((a, indent) => s.value.showWithIndent(repr.to(a), indent))
+}

--- a/core/src/main/scala/cats/derived/showPretty.scala
+++ b/core/src/main/scala/cats/derived/showPretty.scala
@@ -13,7 +13,7 @@ object ShowPretty {
   implicit def fromShow[A](implicit s: Show[A]): ShowPretty[A] =
     new ShowPretty[A] {
       override def showLines(a: A): List[String] =
-        s.show(a).split("\\n")
+        s.show(a).split("\\n").toList
     }
 }
 

--- a/core/src/main/scala/cats/derived/showPretty.scala
+++ b/core/src/main/scala/cats/derived/showPretty.scala
@@ -2,18 +2,18 @@ package cats.derived
 
 import cats.Show
 import shapeless._
-import shapeless.labelled.FieldType
+import shapeless.labelled._
 
 trait ShowPretty[A] extends Show[A] {
-  def showWithIndent(a: A, indent: Int): String
-  def show(a: A): String = showWithIndent(a, 0)
+  def showLines(a: A): List[String]
+  def show(a: A): String = showLines(a).mkString("\n")
 }
 
 object ShowPretty {
   implicit def fromShow[A](implicit s: Show[A]): ShowPretty[A] =
     new ShowPretty[A] {
-      override def showWithIndent(a: A, indent: Int): String =
-        s.show(a)
+      override def showLines(a: A): List[String] =
+        List(s.show(a))
     }
 }
 
@@ -26,25 +26,35 @@ object MkShowPretty extends MkShowPrettyDerivation {
 
 trait MkShowPrettyDerivation extends MkShowPretty1 {
   implicit val emptyProductDerivedShowPretty: MkShowPretty[HNil] =
-    instance((_, _) => "")
+    instance(_ => Nil)
 
   implicit def productDerivedShowPretty[K <: Symbol, V, T <: HList](
       implicit key: Witness.Aux[K],
       showV: ShowPretty[V] OrElse MkShowPretty[V],
       showT: MkShowPretty[T]
-  ): MkShowPretty[FieldType[K, V] :: T] = instance { (fields, indent) =>
+  ): MkShowPretty[FieldType[K, V] :: T] = instance { fields =>
     val fieldName = key.value.name
-    val fieldValue = showV.unify.showWithIndent(fields.head, indent)
-    val nextFields = showT.showWithIndent(fields.tail, indent)
+    val fieldValueLines = showV.unify.showLines(fields.head).flatMap(_.split("\\n"))
+    val nextFields = showT.showLines(fields.tail)
 
-    if (nextFields.isEmpty)
-      s"${" " * indent}$fieldName = $fieldValue"
-    else
-      s"${" " * indent}$fieldName = $fieldValue,\n$nextFields"
+    val fieldValue = {
+      val head = fieldValueLines.headOption.mkString
+      if (nextFields.isEmpty || fieldValueLines.size > 1) head
+      else s"$head,"
+    }
+
+    val remainingLines =
+      if (fieldValueLines.size > 1) {
+        val tail = fieldValueLines.tail
+        if (nextFields.isEmpty) tail
+        else tail.init ++ tail.lastOption.map(s => s"$s,")
+      } else Nil
+
+    List(s"$fieldName = $fieldValue") ++ remainingLines ++ nextFields
   }
 
   implicit def emptyCoproductDerivedShowPretty: MkShowPretty[CNil] =
-    instance((_, _) => "")
+    instance(_ => Nil)
 }
 
 trait MkShowPretty1 extends MkShowPretty2 {
@@ -53,8 +63,8 @@ trait MkShowPretty1 extends MkShowPretty2 {
       showV: ShowPretty[V] OrElse MkShowPretty[V],
       showT: MkShowPretty[T]
   ): MkShowPretty[FieldType[K, V] :+: T] = instance {
-    case (Inl(l), indent) => showV.unify.showWithIndent(l, indent)
-    case (Inr(r), indent) => showT.showWithIndent(r, indent)
+    case Inl(l) => showV.unify.showLines(l)
+    case Inr(r) => showT.showLines(r)
   }
 }
 
@@ -63,22 +73,23 @@ trait MkShowPretty2 extends MkShowPretty3 {
       implicit repr: LabelledGeneric.Aux[A, R],
       t: Typeable[A],
       s: Lazy[MkShowPretty[R]]
-  ): MkShowPretty[A] = instance { (a, indent) =>
+  ): MkShowPretty[A] = instance { a =>
     val name = t.describe.takeWhile(_ != '[')
-    val contents = s.value.showWithIndent(repr.to(a), indent + 2)
-    s"$name(\n$contents\n${" " * indent})"
+    val contentLines = s.value.showLines(repr.to(a))
+    val contents = contentLines.map(s => s"  $s")
+    List(s"$name(") ++ contents ++ List(")")
   }
 }
 
 trait MkShowPretty3 {
-  protected def instance[A](f: (A, Int) => String): MkShowPretty[A] =
+  protected def instance[A](f: A => List[String]): MkShowPretty[A] =
     new MkShowPretty[A] {
-      def showWithIndent(a: A, indent: Int): String = f(a, indent)
+      def showLines(a: A): List[String] = f(a)
     }
 
   implicit def genericDerivedShowPrettyCoproduct[A, R <: Coproduct](
       implicit repr: LabelledGeneric.Aux[A, R],
       s: Lazy[MkShowPretty[R]]
   ): MkShowPretty[A] =
-    instance((a, indent) => s.value.showWithIndent(repr.to(a), indent))
+    instance(a => s.value.showLines(repr.to(a)))
 }

--- a/core/src/main/scala/cats/derived/showPretty.scala
+++ b/core/src/main/scala/cats/derived/showPretty.scala
@@ -13,7 +13,7 @@ object ShowPretty {
   implicit def fromShow[A](implicit s: Show[A]): ShowPretty[A] =
     new ShowPretty[A] {
       override def showLines(a: A): List[String] =
-        List(s.show(a))
+        s.show(a).split("\\n")
     }
 }
 
@@ -34,7 +34,7 @@ trait MkShowPrettyDerivation extends MkShowPretty1 {
       showT: MkShowPretty[T]
   ): MkShowPretty[FieldType[K, V] :: T] = instance { fields =>
     val fieldName = key.value.name
-    val fieldValueLines = showV.unify.showLines(fields.head).flatMap(_.split("\\n"))
+    val fieldValueLines = showV.unify.showLines(fields.head)
     val nextFields = showT.showLines(fields.tail)
 
     val fieldValue = {

--- a/core/src/test/scala/cats/derived/showPretty.scala
+++ b/core/src/test/scala/cats/derived/showPretty.scala
@@ -186,8 +186,8 @@ class ShowPrettyTests extends KittensSuite {
         |ListField(
         |  a = a,
         |  b = List(ListFieldChild(
-        |  c = 1
-        |))
+        |    c = 1
+        |  ))
         |)
       """.stripMargin.trim
     )
@@ -200,8 +200,8 @@ class ShowPrettyTests extends KittensSuite {
         |ListField(
         |  a = a,
         |  b = List(ListFieldChild(
-        |  c = 1
-        |))
+        |    c = 1
+        |  ))
         |)
       """.stripMargin.trim
     )

--- a/core/src/test/scala/cats/derived/showPretty.scala
+++ b/core/src/test/scala/cats/derived/showPretty.scala
@@ -1,0 +1,209 @@
+package cats
+package derived
+
+import cats.Show
+import cats.instances.all._
+import shapeless.test.illTyped
+import TestDefns._
+
+class ShowPrettyTests extends KittensSuite {
+  test("Simple case classes") {
+    implicit val sf = semi.showPretty[Foo]
+    val foo = Foo(42, Option("Hello"))
+    val printedFoo =
+      """
+        |Foo(
+        |  i = 42,
+        |  b = Some(Hello)
+        |)
+      """.stripMargin.trim
+
+    assert(foo.show == printedFoo)
+  }
+
+  test("Nested case classes auto derive inner class") {
+    implicit val so = semi.showPretty[Outer]
+
+    val nested = Outer(Inner(3))
+    val printedNested =
+      """
+        |Outer(
+        |  in = Inner(
+        |    i = 3
+        |  )
+        |)
+      """.stripMargin.trim
+
+    assert(nested.show == printedNested)
+  }
+
+  test("respect defined instance") {
+    import InnerInstance._
+    implicit val so = semi.showPretty[Outer]
+
+    val printedNested =
+      """
+        |Outer(
+        |  in = Blah
+        |)
+      """.stripMargin.trim
+
+    val nested = Outer(Inner(3))
+
+    assert(nested.show == printedNested)
+  }
+
+  test("respect defined instance with full auto derivation") {
+    import InnerInstance._
+    import auto.showPretty._
+
+    val printedNested =
+      """
+        |Outer(
+        |  in = Blah
+        |)
+      """.stripMargin.trim
+
+    val nested = Outer(Inner(3))
+
+    assert(nested.show == printedNested)
+  }
+
+  test("Recursive ADTs with no type parameters") {
+    implicit val st = semi.showPretty[IntTree]
+
+    val tree: IntTree = IntNode(IntLeaf(1), IntNode(IntNode(IntLeaf(2), IntLeaf(3)), IntLeaf(4)))
+    val printedTree =
+      """
+        |IntNode(
+        |  l = IntLeaf(
+        |    t = 1
+        |  ),
+        |  r = IntNode(
+        |    l = IntNode(
+        |      l = IntLeaf(
+        |        t = 2
+        |      ),
+        |      r = IntLeaf(
+        |        t = 3
+        |      )
+        |    ),
+        |    r = IntLeaf(
+        |      t = 4
+        |    )
+        |  )
+        |)
+      """.stripMargin.trim
+
+    assert(tree.show == printedTree)
+  }
+
+  test("Non recursive ADTs with type parameters") {
+    implicit val sg = {
+      import auto.showPretty._
+      semi.showPretty[GenericAdt[Int]]
+    }
+
+    val genAdt: GenericAdt[Int] = GenericAdtCase(Some(1))
+    val printedGenAdt =
+      """
+        |GenericAdtCase(
+        |  v = Some(1)
+        |)
+      """.stripMargin.trim
+
+    assert(genAdt.show == printedGenAdt)
+  }
+
+  test("Recursive ADTs with type parameters are not supported") {
+    import auto.showPretty._
+    val tree: Tree[Int] = Node(Leaf(1), Node(Node(Leaf(2), Leaf(3)), Leaf(4)))
+    illTyped("Show[Tree[Int]]")
+  }
+
+  test("Deep type hierarchy") {
+    semi.showPretty[Top]
+    semi.showPretty[People]
+  }
+
+  test("Deep type hierarchy respect existing instance") {
+    implicit val sAdd : Show[Address] = new Show[Address] {
+      def show(t: Address) = t.street + " " + t.city + " " + t.state
+    }
+
+    val printed =
+      """
+        |People(
+        |  name = Kai,
+        |  contactInfo = ContactInfo(
+        |    phoneNumber = 303-123-4567,
+        |    address = 123 1st St New York NY
+        |  )
+        |)
+      """.stripMargin.trim
+
+    assert(semi.showPretty[People].show(People(name = "Kai",
+      contactInfo = ContactInfo(
+        phoneNumber = "303-123-4567",
+        address = Address(
+          street = "123 1st St",
+          city = "New York", state = "NY") ))) == printed)
+  }
+
+  test("Deep type hierarchy respect existing instance in full auto derivation") {
+    implicit val sAdd : Show[Address] = new Show[Address] {
+      def show(t: Address) = t.street + " " + t.city + " " + t.state
+    }
+
+    val printed =
+      """
+        |People(
+        |  name = Kai,
+        |  contactInfo = ContactInfo(
+        |    phoneNumber = 303-123-4567,
+        |    address = 123 1st St New York NY
+        |  )
+        |)
+      """.stripMargin.trim
+
+    import auto.showPretty._
+    assert(People(name = "Kai",
+      contactInfo = ContactInfo(
+        phoneNumber = "303-123-4567",
+        address = Address(
+          street = "123 1st St",
+          city = "New York", state = "NY") )).show == printed)
+  }
+
+  test("semi-auto derivation respect existing instance") {
+    implicit val lifShow: Show[ListField] = {
+      import auto.showPretty._
+      semi.showPretty
+    }
+
+    assert(ListField(a ="a", b = List(ListFieldChild(c = 1))).show ==
+      """
+        |ListField(
+        |  a = a,
+        |  b = List(ListFieldChild(
+        |  c = 1
+        |))
+        |)
+      """.stripMargin.trim
+    )
+  }
+  test("auto derivation respect existing instance") {
+    import auto.showPretty._
+
+    assert(ListField(a ="a", b = List(ListFieldChild(c = 1))).show ==
+      """
+        |ListField(
+        |  a = a,
+        |  b = List(ListFieldChild(
+        |  c = 1
+        |))
+        |)
+      """.stripMargin.trim
+    )
+  }
+}


### PR DESCRIPTION
This is a proof-of-concept for a `ShowPretty` derivation, which instead of:
```
People(name = Mike, contactInfo = ContactInfo(phoneNumber = 202-295-3928, address = 1 Main ST, Chicago, IL))
```

instead generates the following.
```
People(
  name = Mike,
  contactInfo = ContactInfo(
    phoneNumber = 202-295-3928,
    address = 1 Main ST, Chicago, IL
  )
)
```

I've copied the tests for `Show` derivation and updated them for the pretty printing. Because we respect existing `Show` instances, things like `List` doesn't look nice as we cannot propagate the indentation level -- is there any way we can work around this?